### PR TITLE
Updated course_name_true in scripts to match rosetta definition.

### DIFF
--- a/dbt/models/staging/dashboard/stg_dashboard__scripts.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__scripts.sql
@@ -1,30 +1,31 @@
-with 
+with
 scripts as (
-    select 
+    select
         script_id,
         script_name,
-        case when lower(script_name) like 'csa%'           then 'csa'
-             when lower(script_name) like 'csd%'           then 'csd'
-             when lower(script_name) like 'csf%'           then 'csf'
-             when lower(script_name) like 'csp%'           then 'csp'
-             when lower(script_name) like 'hoc%'           then 'hoc'
-             when lower(script_name) like 'devices-20__'   then 'csd'
-             when lower(script_name) like 'microbit'       then 'csd'
-             else lower(json_extract_path_text(properties,'curriculum_umbrella'))
-        end as course_name_true,
         created_at,
         updated_at,
         wrapup_video_id,
         user_id,
         login_required,
-        json_extract_path_text(properties, 'supported_locales') as supported_locales,
         new_name,
         family_name,
         published_state,
         instruction_type,
         instructor_audience,
-        participant_audience
-    from {{ ref('base_dashboard__scripts')}}
+        participant_audience,
+        case
+            when lower(script_name) like 'devices-20__'                         then 'csd'
+            when lower(script_name) like 'microbit%'                            then 'csd'
+            when lower(script_name) like '%hello%'                              then 'hoc'
+            when lower(script_name) like 'csd-post-survey-20__'                 then 'csd'
+            when lower(script_name) like 'csp-post-survey-20__'                 then 'csp'
+            when
+                json_extract_path_text(properties, 'curriculum_umbrella') = ''  then 'other'
+            else
+                lower(json_extract_path_text(properties, 'curriculum_umbrella'))
+        end as course_name_true,
+        json_extract_path_text(properties, 'supported_locales') as supported_locales
+    from {{ ref('base_dashboard__scripts') }}
 )
-
 select * from scripts


### PR DESCRIPTION
## Description

Updated dashboard_scripts so that the definition of `course_name_true` is derived the same was as the current rosetta version (as of 12.8.23).

TL;DR 
(1) scripts.sql was a prior assigning course name true with the pattern `like 'csp%' then 'csp'`. which doesn't hold in all cases.

(2) much more importantly, it was missing the case that assigns 'other' as a course_name_true.  I have added it.

-