### PR TITLE
fix/base_dashboard__users

### DIFF
--- a/dbt/models/staging/dashboard/base/base_dashboard__users.sql
+++ b/dbt/models/staging/dashboard/base/base_dashboard__users.sql
@@ -2,7 +2,7 @@ with
 source as (
       select * 
       from {{ source('dashboard', 'users') }}
-      where deleted_at is null 
+      --where deleted_at is null 
 ),
 
 renamed as (
@@ -13,7 +13,8 @@ renamed as (
         current_sign_in_at,
         last_sign_in_at,
         created_at,
-        updated_at,        
+        updated_at,
+        deleted_at,        
         gender,
         locale,
         birthday,

--- a/dbt/models/staging/dashboard/stg_dashboard__users.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__users.sql
@@ -43,7 +43,8 @@ renamed as (
         current_sign_in_at,
         last_sign_in_at,
         created_at,
-        updated_at,     
+        updated_at,  
+        deleted_at,   
         purged_at
     from users
 )


### PR DESCRIPTION
## Description

In validating data I was getting weird results (after poking and working my way back realized it was) due to the fact that we're filtering out deleted user accounts in `base_dashboard__users`.

Because we're not filtering out these user ids from other base tables like sign_ins, user_levels, user_geos etc.  it creates a "dangerous" situation where joins are possible between these tables that a modeler might expect would match to all users, but don't.    A regular inner join to the base_users table would filter out those deleted users as you might expect, but a left join will leave some nulls where you might not expect them.  

Furthermore, filtering out deleted accounts at the base prevents us from doing analyses on deleted accounts further downstream - a plausible analysis request.  Another example: tracking account creations over time.  If an account was deleted at a later date, we'd still count its original creation - we don't want to filter out deleted accounts in this case.

This PR is a proposal to include the deleted_at field in the base_users table, and move the decision(s) to exclude deleted user accounts further downstream as choice for the modeler building a model.

This proposal can be rejected upon review.  It may have some *current* downstream impacts for models that have been build with this assumption of deleted accounts baked in.