### PR TITLE
change started_at ended_at to be timestamps

### DIFF
--- a/dbt/models/intermediate/int_school_years.sql
+++ b/dbt/models/intermediate/int_school_years.sql
@@ -1,9 +1,30 @@
+{#
+Casting data types to match analysis.school_years
+
+REFERENCE:
+> DESCRIBE analysis.school_years
+COLUMN_NAME	DATA_TYPE
+school_year	varchar(256)
+school_year_int	integer
+started_at	timestamp
+ended_at	timestamp
+school_year_long	varchar(256)
+
+
+#}
+
 with 
 school_years as (
-    select * 
+    select
+        school_year::varchar,
+        school_year_int::integer,
+        started_at::timestamp,
+        ended_at::timestamp,
+        school_year_long::varchar
     from {{ ref('seed_school_years') }}
 )
 
-select * 
+select
+*
 from school_years
 where current_date >= started_at


### PR DESCRIPTION
## Description

This PR casts the `started_at` and `ended_at` fields in int_school_years to be timestamps.

Directly from the seed file the were loaded as type varchar.  This causes our use of these fields using date logic to incorrectly evaluate expressions using between because it's evaluating the dates as strings.  What's moderately crazy is that this only effects exact date matches. For example:

```
SELECT
*
FROM int_school_years
WHERE '2023-07-01' between started_at and ended_at;
```
Returns null.  But...(change the date July 2)....
```
SELECT
*
FROM int_school_years
WHERE '2023-07-02' between started_at and ended_at;
```
returns the expected row.

This can all be solved/fixed by casting started_at and ended_at as dates/timestamps.

The original analysis.school_years used timestamps so we will here as well.
