### PR TITLE
Feature/add single race, gender, birthday to users

### DIFF
--- a/dbt/models/staging/dashboard/stg_dashboard__users.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__users.sql
@@ -27,10 +27,10 @@ renamed as (
         case when user_type = 'teacher' then user_id end as teacher_id,
         studio_person_id,
 
-        -- user info
+        -- user demogrphic info
         user_type,
         birthday,
-        datediff(year,birthday,current_date ) as age_years,
+        datediff(year,birthday,current_date ) as age_years_today,
         --nullif(lower(gender),'') as gender, 
 
         -- logic for gender code
@@ -46,7 +46,7 @@ renamed as (
         -- logic for making single-race/ethnicity designation. order of operations matters.
         case 
             -- If races matches any of these specific strings, return 'no_response'
-            -- These are all versions of choosing not to respond 
+            -- These are all versions of user choosing not to respond and is distinct from NULL
             when races IN ('closed_dialog', 'nonsense', 'opt_out') THEN 'no_response'
             
             -- hispanic with anything else = hispanic

--- a/dbt/models/staging/dashboard/stg_dashboard__users.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__users.sql
@@ -29,8 +29,39 @@ renamed as (
 
         -- user info
         user_type,
+        birthday,
         datediff(year,birthday,current_date ) as age_years,
-        nullif(lower(gender),'') as gender,
+        --nullif(lower(gender),'') as gender, 
+
+        -- logic for gender code
+        case 
+            when gender = 'm' then 'm'
+            when gender = 'f' then 'f'
+            when gender = 'n' then 'nb' ------  non-binary
+            when gender = 'o' then 'nl' ------  not listed
+            when gender = '' OR gender = '-' then 'no_response' ----  empty string or '-'
+            else null
+        end as gender,
+    
+        -- logic for making single-race/ethnicity designation. order of operations matters.
+        case 
+            -- If races matches any of these specific strings, return 'no_response'
+            -- These are all versions of choosing not to respond 
+            when races IN ('closed_dialog', 'nonsense', 'opt_out') THEN 'no_response'
+            
+            -- hispanic with anything else = hispanic
+            when races LIKE '%hispanic%' THEN 'hispanic'
+
+            -- If races contains a comma, return 'tr' (_T_wo or more _R_aces), a common abbreviation
+            when races LIKE '%,%' THEN 'tr'
+
+            -- If races is NULL, return NULL.  NULL is different from no_response
+            when races IS NULL THEN NULL
+
+            -- Default case: return the input value
+            else races -- should be a single race. Additional logic may be required here in the future
+        END race,
+
         is_urg,
 
         -- misc.

--- a/dbt/models/staging/dashboard/stg_dashboard__users.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__users.sql
@@ -30,7 +30,7 @@ renamed as (
         -- user demogrphic info
         user_type,
         birthday,
-        datediff(year,birthday,current_date ) as age_years_today,
+        datediff(year,birthday,current_date ) as age_years,
         --nullif(lower(gender),'') as gender, 
 
         -- logic for gender code


### PR DESCRIPTION
## Description

This PR does a few things related to fields in the users table - edited at the stg_users level - around user demographic information.

1. add the birthday field -- some analyses require computing student's age on a particular date in the past so this is useful.

2. rename age_years to age_years_today -- this age will potentially change every day so wanted field name to indicate temporal nature.

3. added logic to parse the *gender* code that comes in from production.  This essentially re-alises the single gender codes into more meaningful human-readable codes.

4. added logic to parse the *races* field *and* to expose it -- the logic is what we use to determine the single-race category for users.  Exposing it so that self-serve users can breakdown race in a way they expect.  the is_urg field is still useful and necessary as well.

## Follow-up work - open questions

1. Right now the empty string '' is not a possible result for either gender or races fields, but NULL is.  A prior version of this code converted gender=NULL to the empty string '' (races was ignored).  My preference is to maintain NULL as a hedge against the empty string ever being accidentally inserted into the field, and failing silently.  

2. I've tried to unify the case where the user for whatever reason is declining to response with the value `no_response` as distinct from NULL which would mean they never were even presented with the dialog to self-identify.  I'm not in love with 'no_response' as a value because NULL is also a type of no response.  But I couldn't think of anything short and pithy that would convey 'user elected not to respond'