### PR TITLE
fix/dim_teachers

### DIFF
--- a/dbt/models/marts/teachers/dim_teachers.sql
+++ b/dbt/models/marts/teachers/dim_teachers.sql
@@ -2,11 +2,13 @@ with
 teachers as (
     select 
     {{ dbt_utils.star(
-        from=ref('stg_dashboard__users'),
+        from=ref('stg_dashboard_pii__users'),
         except=["user_id",
             "is_urg",
-            "student_id"]) }}
-    from {{ ref('stg_dashboard__users') }}
+            "student_id",
+            "birthday",
+            "school_info_id"]) }}
+    from {{ ref('stg_dashboard_pii__users') }}
     where teacher_id is not null 
 ),
 

--- a/dbt/models/staging/dashboard/base/base_dashboard__followers.sql
+++ b/dbt/models/staging/dashboard/base/base_dashboard__followers.sql
@@ -2,7 +2,6 @@ with
 source as (
     select * 
     from {{ source('dashboard', 'followers') }}
-    where deleted_at is null 
 ),
 
 renamed as (

--- a/dbt/models/staging/dashboard_pii/base/base_dashboard_pii__users.sql
+++ b/dbt/models/staging/dashboard_pii/base/base_dashboard_pii__users.sql
@@ -2,26 +2,27 @@ with
 source as (
     select * 
     from {{ source('dashboard_pii', 'users') }}
-    where not deleted_at
 ),
 
 renamed as (
     select
         id                          as user_id,
         studio_person_id,
+        email,
         sign_in_count,
         current_sign_in_at,
         last_sign_in_at,
         created_at,
         updated_at,
-        -- username,
+        deleted_at,
+        username,
         provider,
         uid,
         admin,
-        -- gender,
-        -- name,
+        gender,
+        name,
         locale,
-        -- birthday,
+        birthday,
         user_type,
         school,
         full_address,
@@ -32,7 +33,7 @@ renamed as (
         invited_by_id,
         invited_by_type,
         terms_of_service_version,
-        urm                         as is_urm,
+        urm                         as is_urg,
         -- races,
         primary_contact_info_id
 

--- a/dbt/models/staging/dashboard_pii/stg_dashboard_pii__users.sql
+++ b/dbt/models/staging/dashboard_pii/stg_dashboard_pii__users.sql
@@ -1,8 +1,56 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='user_id')
+}}
+
 with 
 users as (
-    select * 
+    select *
     from {{ ref('base_dashboard_pii__users') }}
+    where is_active
+
+    {% if is_incremental() %}
+
+    and updated_at > (select max(updated_at) from {{ this }} )
+    
+    {% endif %}
+),
+
+renamed as (
+    select 
+        -- PK
+        user_id,
+
+        -- FK's
+        case when user_type = 'student' then user_id end as student_id,
+        case when user_type = 'teacher' then user_id end as teacher_id,
+        studio_person_id,
+
+        --PII
+        email,
+
+        -- user info
+        user_type,
+        datediff(year,birthday,current_date ) as age_years,
+        nullif(lower(gender),'') as gender,
+        is_urg,
+
+        -- misc.
+        locale,
+        sign_in_count,
+        school_info_id,
+        total_lines,
+
+        -- dates         
+        current_sign_in_at,
+        last_sign_in_at,
+        created_at,
+        updated_at,  
+        deleted_at,   
+        purged_at
+    from users
 )
 
 select * 
-from users
+from renamed


### PR DESCRIPTION
What's the fix?

Add PII info (email, username, name) to dim_teachers and make underlying staging model incremental. 

Why?

Marketing is often needing to pull teacher email addresses (and sometimes names) based on whether or not they still use code.org. Our models would allow them to do this if these PII fields were added to dim_teachers. This PII is already made available to them (and the org) through various google sheets, so was approved by Travis to be user-facing in Trevor. No PII is in the code itself. 