### PR TITLE
fix/int_section_mapping

### DIFF
--- a/dbt/models/intermediate/int_section_mapping.sql
+++ b/dbt/models/intermediate/int_section_mapping.sql
@@ -24,13 +24,6 @@ followers as (
     from {{ ref('stg_dashboard__followers') }}
 ),
 
--- teachers as (
---     select distinct 
---         teacher_id,
---         school_id
---     from {{ ref('dim_teachers') }}
--- ),
-
 teacher_school_changes as (
     select *
     from {{ ref('int_teacher_schools_historical') }}
@@ -61,8 +54,6 @@ combined as (
     from followers  
     left join sections 
         on followers.section_id = sections.section_id
-    -- left join teachers 
-    --     on sections.user_id = teachers.teacher_id
     join school_years as sy 
         on followers.created_at 
             between sy.started_at and sy.ended_at


### PR DESCRIPTION
What's the fix? 

Before, int_section_mapping was not incorporating historical school changes for teacher-school associations by school year. With the fix, it should be incorporating them in the same way dim_school_status does as well. 

Note: I used teacher_id = 49619110 to validate the results, since they originally did not have a school association in int_section_mapping when they should have been associated with school_id = 170993001027