### PR TITLE
Feature/sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After you set up dbt, try running the following commands:
 * `dbt run --select /dbt/models/marts/*`
 
 #### Resources:
-* Please refer to our `sql`/`dbt` [style guide] for building models
+* Please refer to our `sql`/`dbt` [style guide](https://docs.getdbt.com/best-practices/how-we-style/1-how-we-style-our-dbt-models) for building models
 * For a more detailed guide on buildilng our `dbt-project` see [here](https://handbook.gitlab.com/handbook/business-technology/data-team/platform/dbt-guide/)
 * Join the chat on [Slack](getdbt.slack.com) for live discussions and support
 * Check out the [blog](https://docs.getdbt.com/blog) for the latest news on dbt's development and best practices

--- a/dbt/models/intermediate/int_section_mapping.sql
+++ b/dbt/models/intermediate/int_section_mapping.sql
@@ -24,16 +24,14 @@ followers as (
     from {{ ref('stg_dashboard__followers') }}
 ),
 
-teachers as (
-    select distinct 
-        teacher_id,
-        school_id
-    from {{ ref('dim_teachers') }}
+teacher_school_changes as (
+    select *
+    from {{ ref('int_teacher_schools_historical') }}
 ),
 
 sections as (
     select distinct 
-        user_id,
+        teacher_id,
         section_id
     from {{ ref('stg_dashboard__sections') }}
 ),
@@ -42,9 +40,9 @@ combined as (
     select 
         sy.school_year, 
         followers.student_id,
-        sections.user_id            as teacher_id,
+        sections.teacher_id,
         sections.section_id         as section_id,
-        teachers.school_id,
+        tsc.school_id,
         row_number() over(
             partition by 
                 followers.student_id, 
@@ -56,11 +54,13 @@ combined as (
     from followers  
     left join sections 
         on followers.section_id = sections.section_id
-    left join teachers 
-        on sections.user_id = teachers.teacher_id
+    -- left join teachers 
+    --     on sections.user_id = teachers.teacher_id
     join school_years as sy 
-        on followers.created_at 
-            between sy.started_at and sy.ended_at
+        on followers.created_at between sy.started_at and sy.ended_at
+    left join teacher_school_changes tsc 
+        on sections.teacher_id = tsc.teacher_id 
+        and sy.ended_at between tsc.started_at and tsc.ended_at 
 ),
 
 final as (

--- a/dbt/models/marts/sections/_sections.yml
+++ b/dbt/models/marts/sections/_sections.yml
@@ -7,6 +7,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - teacher_id
-            - school_year
+            - created_at_school_year
+            - added_students_school_year
             - course_name
             - section_id

--- a/dbt/models/marts/sections/_sections.yml
+++ b/dbt/models/marts/sections/_sections.yml
@@ -1,0 +1,12 @@
+version: 2
+
+models: 
+  - name: dim_sections
+    description: all sections ever created, with activity metrics for those that are "active" (5+ students completing 1+ levels of same course)
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - teacher_id
+            - school_year
+            - course_name
+            - section_id

--- a/dbt/models/marts/sections/dim_sections.sql
+++ b/dbt/models/marts/sections/dim_sections.sql
@@ -1,8 +1,19 @@
 with 
+school_years as (
+    select * 
+    from {{ ref('int_school_years') }}
+),
+
+teacher_school_changes as (
+    select *
+    from {{ ref('int_teacher_schools_historical') }}
+),
+
 sections as (
     select 
         section_id,
         section_name, 
+        teacher_id,
         login_type,
         grade,
         created_at,
@@ -34,26 +45,39 @@ active_sections as (
         course_name,
         1 as is_active
     from {{ ref('int_active_sections') }}
+),
+
+all_sections_mapping as (
+    select 
+        sections.*, 
+        tsc.school_id,
+        sy.school_year as created_at_school_year
+    from sections 
+    join school_years sy 
+        on sections.created_at between sy.started_at and sy.ended_at 
+    join teacher_school_changes tsc 
+        on sections.teacher_id = tsc.teacher_id 
+        and sy.ended_at between tsc.started_at and tsc.ended_at 
 )
 
 select 
-    section_metrics.section_id,
-    section_metrics.teacher_id,
-    section_metrics.school_id,
-    section_metrics.school_year,
-    sections.section_name, 
-    sections.login_type,
-    sections.grade,
-    sections.created_at,
-    sections.updated_at,
+    asm.section_id,
+    asm.teacher_id,
+    asm.school_id,
+    asm.created_at_school_year,
+    section_metrics.school_year                                 as added_students_school_year,
+    asm.section_name, 
+    asm.login_type,
+    asm.grade,
+    asm.created_at,
+    asm.updated_at,
     section_metrics.num_students_added,
     active_sections.num_students                                as num_students_active,
     active_sections.course_name,
     case when active_sections.is_active = 1 then 1 else 0 end   as is_active 
-from section_metrics
-left join sections 
-    on section_metrics.section_id = sections.section_id
+from all_sections_mapping asm
+left join section_metrics 
+    on section_metrics.section_id = asm.section_id
 left join active_sections
     on section_metrics.section_id = active_sections.section_id
     and section_metrics.school_year = active_sections.school_year
-

--- a/dbt/models/marts/sections/dim_sections.sql
+++ b/dbt/models/marts/sections/dim_sections.sql
@@ -31,6 +31,7 @@ active_sections as (
         section_id,
         school_year,
         num_students,
+        course_name,
         1 as is_active
     from {{ ref('int_active_sections') }}
 )
@@ -47,6 +48,7 @@ select
     sections.updated_at,
     section_metrics.num_students_added,
     active_sections.num_students                                as num_students_active,
+    active_sections.course_name,
     case when active_sections.is_active = 1 then 1 else 0 end   as is_active 
 from section_metrics
 left join sections 

--- a/dbt/models/marts/sections/dim_sections.sql
+++ b/dbt/models/marts/sections/dim_sections.sql
@@ -1,0 +1,57 @@
+with 
+sections as (
+    select 
+        section_id,
+        section_name, 
+        login_type,
+        grade,
+        created_at,
+        updated_at 
+    from {{ ref('stg_dashboard__sections') }}
+),
+
+int_section_mapping as (
+    select * 
+    from {{ ref('int_section_mapping') }}
+),
+
+section_metrics as (
+    select
+        section_id,
+        teacher_id,
+        school_id,
+        school_year,
+        count(distinct student_id) as num_students_added
+    from {{ ref('int_section_mapping') }}
+    group by 1, 2, 3, 4
+),
+
+active_sections as (
+    select 
+        section_id,
+        school_year,
+        num_students,
+        1 as is_active
+    from {{ ref('int_active_sections') }}
+)
+
+select 
+    section_metrics.section_id,
+    section_metrics.teacher_id,
+    section_metrics.school_id,
+    section_metrics.school_year,
+    sections.section_name, 
+    sections.login_type,
+    sections.grade,
+    sections.created_at,
+    sections.updated_at,
+    section_metrics.num_students_added,
+    active_sections.num_students                                as num_students_active,
+    case when active_sections.is_active = 1 then 1 else 0 end   as is_active 
+from section_metrics
+left join sections 
+    on section_metrics.section_id = sections.section_id
+left join active_sections
+    on section_metrics.section_id = active_sections.section_id
+    and section_metrics.school_year = active_sections.school_year
+

--- a/dbt/models/staging/dashboard/base/base_dashboard__sections.sql
+++ b/dbt/models/staging/dashboard/base/base_dashboard__sections.sql
@@ -11,8 +11,7 @@ renamed as (
         id                      as section_id,
         name                    as section_name,
         section_type,
-
-        user_id,
+        user_id                 as teacher_id,
         login_type,
         code,
         script_id,


### PR DESCRIPTION
_**Most recent updates**_
1. made all sections models account for teacher school changes, instead of pulling in most recent school from dim_teachers
2. dim_sections now includes every section created with two fields for created_at_school_year and students_added_school_year. Before, we were only including sections that had students assigned to them. 

Note: I chose to leave num_students null for sections that did not have students added to them, but there could be an argument for this to be 0. I'd be concerned about misinterpreting aggregations such as avg(num_students) without filtering out those without followers. 


**What?**

This PR adds dim_sections which includes all sections ever created. Aside from basic dimensional information about each section (e.g. name, login_type, etc), it adds:
1. a flag for is_active
4. calculations for the number of students added (num_students_added) and 
5. the number of active students if the section is active (num_students_active)

**How would this be used?**

This model is meant to be user-facing in trevor and help answer questions like: 
- how big are active sections in terms of total students added and active students? 
- how many active sections are there for CSF in 22-23? 

**Additional notes**

This model pulls in all the information from int_active_sections for all sections who are active. Thus, we would NOT need to make int_active_sections user facing anymore with the addition of this model. 