### PR TITLE
Feature/add country to monthly account metrics

### DIFF
--- a/dbt/models/marts/metrics/_metrics__models.yml
+++ b/dbt/models/marts/metrics/_metrics__models.yml
@@ -59,11 +59,12 @@ models:
 
   
   - name: fct_monthly_accounts_created
-    description: number of user accounts created by month. This only includes accounts that have been signed into at least once (there are cases where teachers can create accounts to pre-populate a section, but no student ever signs in with it).
+    description: number of user accounts created by month, segmented by country. This only includes accounts that have been signed into at least once (there are cases where teachers can create accounts to pre-populate a section, but no student ever signs in with it).
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - user_type
+            - country
             - us_intl
             - created_at_year
             - created_at_month
@@ -80,10 +81,13 @@ models:
         #   - not_null
           
       - name: us_intl
-        description: whether the account was created by a user inside or outside the US
+        description: whether the account was created by a user inside or outside the US. Possible values are (us | intl).
         tests:
           - not_null
           
+      - name: country
+        description: the current geo-located country associated with this user.  Note - this can change over time. When `us_intl` = 'us' then country = "United States". All other countries are flaged as "intl"
+       
       - name: created_at_school_year
         description: school year in which the accounts were created
         tests:

--- a/dbt/models/marts/metrics/_metrics__models.yml
+++ b/dbt/models/marts/metrics/_metrics__models.yml
@@ -82,8 +82,6 @@ models:
           
       - name: us_intl
         description: whether the account was created by a user inside or outside the US. Possible values are (us | intl).
-        tests:
-          - not_null
           
       - name: country
         description: the current geo-located country associated with this user.  Note - this can change over time. When `us_intl` = 'us' then country = "United States". All other countries are flaged as "intl"
@@ -113,6 +111,7 @@ models:
           combination_of_columns:
             - user_type
             - us_intl
+            - country
             - sign_in_year
             - sign_in_month
     columns:
@@ -126,9 +125,10 @@ models:
                 warn_if: "=3"
       
       - name: us_intl
-        description: whether the user who signed in was in the US or outside the US
-        tests:
-          - not_null
+        description: whether the user who signed in was in the US or outside the US. Values are one of (us | intl)
+
+      - name: country
+        description: the current geo-located country associated with this user.  Note - this can change over time. When `us_intl` = 'us' then country = "United States". All other countries are flaged as "intl"
       
       - name: sign_in_school_year
         description: school year in which users signed in

--- a/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
+++ b/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
@@ -18,7 +18,8 @@ users as (
 user_geos as (
     select 
         user_id,
-        is_international
+        is_international,
+        country
     from {{ref('stg_dashboard__user_geos')}}
     where user_id in (select user_id from users)
 ),
@@ -28,7 +29,8 @@ combined as (
         u.user_id,
         u.created_at,
         u.user_type,
-        ug.is_international
+        ug.is_international,
+        ug.country
     from users u
     left join user_geos ug 
         on ug.user_id = u.user_id
@@ -42,6 +44,7 @@ school_years as (
 final as (
     select
         c.user_type,
+        c.country,
         case when c.is_international = 1 then 'intl' else 'us' end  as us_intl,
         sy.school_year                                              as created_at_school_year,
         date_part(year, c.created_at)                               as created_at_year,
@@ -51,7 +54,7 @@ final as (
     left join school_years as sy 
         on c.created_at 
             between sy.started_at and sy.ended_at
-    {{ dbt_utils.group_by(5) }}
+    {{ dbt_utils.group_by(6) }}
 )
 
 select * 

--- a/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
+++ b/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
@@ -4,39 +4,14 @@ are tricky since this is an aggregated metrics table where the current month wil
 day, but past months should remain unchanged.  
 #}
 
-with 
--- users as (
---     select 
---         user_id,
---         user_type,
---         created_at,
---         current_sign_in_at
---     from {{ref('stg_dashboard__users')}}
---     where current_sign_in_at is not null 
--- ),
-
--- user_geos as (
---     select 
---         user_id,
---         is_international,
---         country
---     from {{ref('stg_dashboard__user_geos')}}
---     where user_id in (select user_id from users)
--- ),
-
--- combined as (
---     select 
---         u.user_id,
---         u.created_at,
---         u.user_type,
---         ug.is_international,
---         ug.country
---     from users u
---     left join user_geos ug 
---         on ug.user_id = u.user_id
--- ),
-all_users as (
-    select *
+with all_users as (
+    select
+        user_id,
+        created_at,
+        user_type,
+        is_international,
+        us_intl,
+        country
     from {{ref('dim_users')}}
 )
 , school_years as (
@@ -46,17 +21,16 @@ all_users as (
 
 final as (
     select
-        c.user_type,
-        c.country,
-        c.us_intl,
-        --case when c.is_international = 1 then 'intl' else 'us' end  as us_intl,
+        u.user_type,
+        u.country,
+        u.us_intl,
         sy.school_year                                              as created_at_school_year,
-        date_part(year, c.created_at)                               as created_at_year,
-        date_part(month, c.created_at)                              as created_at_month,
-        count(distinct c.user_id)                                   as num_accounts
-    from all_users as c
+        date_part(year, u.created_at)                               as created_at_year,
+        date_part(month, u.created_at)                              as created_at_month,
+        count(distinct u.user_id)                                   as num_accounts
+    from all_users as u
     left join school_years as sy 
-        on c.created_at 
+        on u.created_at 
             between sy.started_at and sy.ended_at
     {{ dbt_utils.group_by(6) }}
 )

--- a/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
+++ b/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
@@ -5,38 +5,41 @@ day, but past months should remain unchanged.
 #}
 
 with 
-users as (
-    select 
-        user_id,
-        user_type,
-        created_at,
-        current_sign_in_at
-    from {{ref('stg_dashboard__users')}}
-    where current_sign_in_at is not null 
-),
+-- users as (
+--     select 
+--         user_id,
+--         user_type,
+--         created_at,
+--         current_sign_in_at
+--     from {{ref('stg_dashboard__users')}}
+--     where current_sign_in_at is not null 
+-- ),
 
-user_geos as (
-    select 
-        user_id,
-        is_international,
-        country
-    from {{ref('stg_dashboard__user_geos')}}
-    where user_id in (select user_id from users)
-),
+-- user_geos as (
+--     select 
+--         user_id,
+--         is_international,
+--         country
+--     from {{ref('stg_dashboard__user_geos')}}
+--     where user_id in (select user_id from users)
+-- ),
 
-combined as (
-    select 
-        u.user_id,
-        u.created_at,
-        u.user_type,
-        ug.is_international,
-        ug.country
-    from users u
-    left join user_geos ug 
-        on ug.user_id = u.user_id
-),
-
-school_years as (
+-- combined as (
+--     select 
+--         u.user_id,
+--         u.created_at,
+--         u.user_type,
+--         ug.is_international,
+--         ug.country
+--     from users u
+--     left join user_geos ug 
+--         on ug.user_id = u.user_id
+-- ),
+all_users as (
+    select *
+    from {{ref('dim_users')}}
+)
+, school_years as (
     select *
     from {{ ref('int_school_years') }}
 ),
@@ -45,12 +48,13 @@ final as (
     select
         c.user_type,
         c.country,
-        case when c.is_international = 1 then 'intl' else 'us' end  as us_intl,
+        c.us_intl,
+        --case when c.is_international = 1 then 'intl' else 'us' end  as us_intl,
         sy.school_year                                              as created_at_school_year,
         date_part(year, c.created_at)                               as created_at_year,
         date_part(month, c.created_at)                              as created_at_month,
         count(distinct c.user_id)                                   as num_accounts
-    from combined as c
+    from all_users as c
     left join school_years as sy 
         on c.created_at 
             between sy.started_at and sy.ended_at

--- a/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
+++ b/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
@@ -12,9 +12,10 @@ with all_users as (
         is_international,
         us_intl,
         country
-    from {{ref('dim_users')}}
-)
-, school_years as (
+    from {{ ref('dim_users') }}
+),
+
+school_years as (
     select *
     from {{ ref('int_school_years') }}
 ),
@@ -24,16 +25,17 @@ final as (
         u.user_type,
         u.country,
         u.us_intl,
-        sy.school_year                                              as created_at_school_year,
-        date_part(year, u.created_at)                               as created_at_year,
-        date_part(month, u.created_at)                              as created_at_month,
-        count(distinct u.user_id)                                   as num_accounts
+        sy.school_year                  as created_at_school_year,
+        date_part(year, u.created_at)   as created_at_year,
+        date_part(month, u.created_at)  as created_at_month,
+        count(distinct u.user_id)       as num_accounts
     from all_users as u
-    left join school_years as sy 
-        on u.created_at 
+    left join school_years as sy
+        on
+            u.created_at
             between sy.started_at and sy.ended_at
     {{ dbt_utils.group_by(6) }}
 )
 
-select * 
+select *
 from final

--- a/dbt/models/marts/metrics/fct_monthly_signed_in_users.sql
+++ b/dbt/models/marts/metrics/fct_monthly_signed_in_users.sql
@@ -4,10 +4,10 @@ are tricky since this is an aggregated metrics table where the current month wil
 day, but past months should remain unchanged.  
 #}
 
-with 
+with
 sign_ins as (
     select *
-    from {{ ref('stg_dashboard__sign_ins')}}
+    from {{ ref('stg_dashboard__sign_ins') }}
 ),
 
 users as (
@@ -29,21 +29,21 @@ final as (
     select
         u.user_type,
         u.country,
-        --case when u.is_international = 1 then 'intl' else 'us' end as us_intl,
         u.us_intl,
-        sy.school_year as sign_in_school_year,
-        extract(year from si.sign_in_at) as sign_in_year,
-        extract(month from si.sign_in_at) as sign_in_month,
-        count(distinct si.user_id) as num_signed_in_users
+        sy.school_year                      as sign_in_school_year,
+        extract(year from si.sign_in_at)    as sign_in_year,
+        extract(month from si.sign_in_at)   as sign_in_month,
+        count(distinct si.user_id)          as num_signed_in_users
 
     from sign_ins as si
-    left join users u 
+    left join users as u
         on si.user_id = u.user_id
-    left join school_years sy
-        on sign_in_at 
+    left join school_years as sy
+        on
+            sign_in_at
             between sy.started_at and sy.ended_at
     {{ dbt_utils.group_by(6) }}
 )
 
-select * 
+select *
 from final

--- a/dbt/models/marts/metrics/fct_monthly_signed_in_users.sql
+++ b/dbt/models/marts/metrics/fct_monthly_signed_in_users.sql
@@ -14,7 +14,9 @@ users as (
     select
         user_id,
         user_type,
-        is_international
+        is_international,
+        us_intl,
+        country
     from {{ ref('dim_users') }}
 ),
 
@@ -26,7 +28,9 @@ school_years as (
 final as (
     select
         u.user_type,
-        case when u.is_international = 1 then 'intl' else 'us' end as us_intl,
+        u.country,
+        --case when u.is_international = 1 then 'intl' else 'us' end as us_intl,
+        u.us_intl,
         sy.school_year as sign_in_school_year,
         extract(year from si.sign_in_at) as sign_in_year,
         extract(month from si.sign_in_at) as sign_in_month,
@@ -38,7 +42,7 @@ final as (
     left join school_years sy
         on sign_in_at 
             between sy.started_at and sy.ended_at
-    {{ dbt_utils.group_by(5) }}
+    {{ dbt_utils.group_by(6) }}
 )
 
 select * 

--- a/dbt/models/marts/users/dim_users.sql
+++ b/dbt/models/marts/users/dim_users.sql
@@ -22,7 +22,8 @@ final as (
         users_pii.race_group,
         users_pii.gender_group,
         ug.is_international,
-        case when ug.is_international = 1 then 'international' else 'united states' end as us_intl
+        case when ug.is_international = 1 then 'international' else 'united states' end as us_intl,
+        ug.country
     from users 
     left join users_pii 
         on users.user_id = users_pii.user_id


### PR DESCRIPTION
## Description

Add `country` to the grain of monthly metrics tables.

This PR started in response to a request to add `country` to monthly account creation and signin metrics tables, rather than just having `us_intl` field.  This change keeps `us_intl` and adds `country`.  Along the way, I found and made a few other updates.  Here are the substantive changes.

1. added `country` to `dim_users` so the user_geo information is now carried along with all the other helpful stuff in `dim_users`.  Useful!

2. added `country`  to `fct_monthly_signed_in_users` (via `dim_users`)

3. updated `fct_monthly_accounts_created` to use `dim_users`.  Rather than joining stg_users and stg_user_geos as CTEs in this model, the same thing now happens upstream in `dim_users`, so just pull it in.

4. added `country` to `fct_monthly_accounts_created` (via `dim_users`)

5. updated models to pull text label `us_intl` from `dim_users` rather than re-creating in metrics models.

6. update docs and tests accordingly (`us_intl` had a test for `not null` in the metrics tables, but I think it should be allowed to be null since not all users have geo-mapping.  Additionally, there was no test for it in `dim_users` where it originated.)

## Links

Jira ticket(s): [Martina, 2 new dimensions for New accounts created](https://codedotorg.atlassian.net/browse/DATAOPS-517?atlOrigin=eyJpIjoiMGZmZmUwYzNkMWYzNDE3Y2I5NjI0NWIxNzcwMzcxZjMiLCJwIjoiaiJ9)

## Testing story

- [X] Does your change include appropriate tests on key columns?

## Privacy
No new issues.

## Future work

* need to create saved queries in Trevor to properly handle calculating US v. international metrics now that country is part of the grain. Esp. for international you need to sum across us_intl = 'intl' which may not be obvious to casual user.

