### PR TITLE
Exclude Dummy Accounts from fct_monthly_accounts_created

### DIFF
--- a/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
+++ b/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
@@ -13,6 +13,7 @@ with all_users as (
         us_intl,
         country
     from {{ ref('dim_users') }}
+    where current_sign_in_at IS NOT NULL
 ),
 
 school_years as (

--- a/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
+++ b/dbt/models/marts/metrics/fct_monthly_accounts_created.sql
@@ -13,7 +13,7 @@ with all_users as (
         us_intl,
         country
     from {{ ref('dim_users') }}
-    where current_sign_in_at IS NOT NULL
+    where current_sign_in_at is not null -- exclude dummy accounts
 ),
 
 school_years as (


### PR DESCRIPTION
## Description

Small fix.  

Need to exclude dummy accounts (accounts where `current_sign_in_at IS NULL`) from the `fct_monthly_accounts_created` metrics table. 

This error was an oversight when we switched this metrics table to sourcing from `dim_users`. 

It was brought to our attention by Martina.

## Links

Jira ticket(s): [dataops-540](https://codedotorg.atlassian.net/browse/DATAOPS-540)

## Testing story

The sum of all accounts created in `fct_monthly_accounts_created` should be equal to (the same number as) the count distinct of user_ids pulled from `dim_users`.  This code should show the same number of student and teacher accounts created pulled from each of those sources.  It simulates how we count the "all-time accounts created" metric for the annual report.

```
with fct as (
    select 
    sum(num_accounts),
    user_type
from {{ ref('fct_monthly_accounts_created') }}
where created_at_year NOT IN ('2024')
group by 2
)
, users as (
    select
        count(distinct user_id) num_users,
        user_type
    from {{ref('dim_users')}}
    where created_at < '2024-01-01'
    and current_sign_in_at IS NOT NULL
    group by 2
)
SELECT
'fct' as dataset,
*
from fct

union all

select
'dim_users' as dataset,
*
from users
```

