### PR TITLE
made a mart for level concept difficulties

### DIFF
--- a/dbt/models/marts/courses/_courses__models.yml
+++ b/dbt/models/marts/courses/_courses__models.yml
@@ -31,3 +31,15 @@ models:
         tests: 
           - unique
           - not_null
+
+  - name: dim_level_concept_difficulties
+    description: this table is full listing of EVERY level in course structure showing the mapping to any/all "concepts and difficulties" for use in the "coding proficiency" metric.  
+    columns: 
+      - name: level_id
+        description: id of the level being mapped
+        tests: 
+          - not_null
+      - name: has_lcd_mapping
+        description: yes|no does this level have a mapping for concept-difficulty
+      - name: course_family
+        description: the short name for which course this script/level combo belongs to e.g. csf, csd, csp, csa, hoc, etc.

--- a/dbt/models/marts/courses/dim_level_concept_difficulties.sql
+++ b/dbt/models/marts/courses/dim_level_concept_difficulties.sql
@@ -1,0 +1,35 @@
+with level_concept_difficulties as (
+    select * from {{ ref('stg_dashboard__level_concept_difficulties') }}
+)
+, course_structure as (
+    select * from {{ref('dim_course_structure')}}
+)
+, final as (
+    select
+    cs.script_name,
+    cs.stage_number,
+    cs.stage_name, 
+    cs.level_name,
+    cs.level_script_order,
+    cs.level_id,
+    cs.course_name_true course_family,
+    --lcd.level_id,
+    --lcd.created_at,
+    --lcd.updated_at,
+    case when lcd.level_id is null then 'no' else 'yes' end has_lcd_mapping,
+    lcd.sequencing,
+    lcd.debugging,
+    lcd.repeat_loops,
+    lcd.repeat_until_while,
+    lcd.for_loops,
+    lcd.events,
+    lcd.variables,
+    lcd.functions,
+    lcd.functions_with_params,
+    lcd.conditionals
+
+from course_structure cs 
+left join level_concept_difficulties lcd on lcd.level_id = cs.level_id
+)
+select *
+from final

--- a/dbt/models/staging/dashboard/stg_dashboard__level_concept_difficulties.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__level_concept_difficulties.sql
@@ -6,7 +6,7 @@ level_concept_difficulties as (
 
 final as (
     select 
-        -- level_concept_difficulty_id,
+        level_concept_difficulty_id,
         level_id,
         
         sequencing,


### PR DESCRIPTION
# Description

This PR creates a Mart for level concept difficulties that joins that base table with course structure, so that users can more easily look up whether or not, and how, a level has been tagged with concepts and difficulty.

# Testing
I believe I have successfully done the following:

1. The model compiles (`dbt build -m 'your_model'`)
         or: _has the dbt Cloud job succeeded?_
3. The model runs (`dbt run -m 'your_model'`)
4. The model produces accessible data in the DW (`select 1 from 'your_model'`)

## Privacy

- [ ] 1.	Does this change involve the collection, use, or sharing of new Personal Data?
- [ ] 2.    Do these data exist in the appropriate schema(s)? 
- [ ] 3.	Does this change involve a new or changed use or sharing of existing Personal Data?
- [ ] 4.    Consider: will this data be visible on Tableau? will this data be surfaced in a report exported from Trevor?
- [ ] 5.    If yes to any of the above, please list the models, columns, and justification below:

1-3 - No.
Intending to expose in trevor, yes.


## PR Checklist:
**Note: if these are not all checked, the PR will be sent back.**

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code adheres to [style guide](https://docs.getdbt.com/best-practices/how-we-style/0-how-we-style-our-dbt-projects)👀 and is **[DRY](https://docs.getdbt.com/terms/dry)**
- [ ] Code is well-commented (**please do not leave extraneous commentary in model code, if it is for the purpose of documentation, please relocate accordingly)
- [ ] Appropriate documentation has been provided (see `.yml.`, did `dbt docs generate` succeed?)
- [ ] New features are translatable or updates will not break up/downstream models
- [ ] Relevant documentation has been added or updated (i.e. `dbt docs` has been updated successfully on [Github Pages](code-dot-org.github.io/analytics/)
- [ ] Pull Request is labeled appropriately (eg. `chore/`, `feature/`, `fix/`)
- [ ] Follow-up work items (including potential tech debt) are tracked and linked (if applicable)



<!--
changelog:
auth.      descr.      date
js         init        2024-01-22              
js         v1.2        2024-02-06
-->
