### PR TITLE
Revert "updating alias for dim_schools.school_year"

### DIFF
--- a/dbt/models/marts/schools/_schools__models.yml
+++ b/dbt/models/marts/schools/_schools__models.yml
@@ -34,16 +34,12 @@ models:
     columns:
       - name: school_id
         description: NCES school ID (this school must have been selected by teacher via NCES dropdown in account setup)
-      
       - name: school_year
         description: school year in which an activity status is assigned
-      
       - name: status
         description: '{{ doc("dim_school_status_status") }}'
-      
       - name: school_started_at
         description: time of first activity from an active section at this school in this school year
-      
       - name: active_courses
         description: comma separated list of courses associated with active sections at this school in this school year
 
@@ -55,21 +51,15 @@ models:
         tests:
           - not_null
           - unique
-
-      - name: most_recent_survey_school_year # fka: school_year
+      - name: school_year
         description: the school year associated with the most recent information about this school from NCES
-      
       - name: is_stage_el
         description: binary; 1 if the school has any grade levels 0-5, 0 if not 
-      
       - name: is_stage_mi
         description: binary; 1 if the school has any grade levels 6-8, 0 if not 
-      
       - name: is_stage_hi
         description: binary; 1 if the school has any grade levels 9-12, 0 if not 
-      
       - name: school_level_simple
         description: a combination of all school levels the school contains, separated by underscores
-      
       - name: total_urg_no_tr_students
         description: total number of URG students, excluding those identifying as two or more races

--- a/dbt/models/marts/schools/dim_schools.sql
+++ b/dbt/models/marts/schools/dim_schools.sql
@@ -12,12 +12,7 @@ school_districts as (
 ),
 
 school_stats_by_years as (
-    select *, 
-        row_number() 
-            over(
-                partition by school_id 
-                order by school_year desc) as row_num
-
+    select *, row_number() over(partition by school_id order by school_year desc) as row_num
     from {{ ref('stg_dashboard__school_stats_by_years') }}
 ),
 
@@ -28,29 +23,24 @@ combined as (
         schools.city,
         schools.state,
         schools.zip,
-
-        school_stats_by_years.school_year   as most_recent_survey_school_year,
+        school_stats_by_years.school_year,
         school_stats_by_years.is_stage_el,
         school_stats_by_years.is_stage_mi,
         school_stats_by_years.is_stage_hi,
-        
         (
             (case when school_stats_by_years.is_stage_el = 1 then 'el' else '__' end ) ||
             (case when school_stats_by_years.is_stage_mi = 1 then 'mi' else '__' end ) ||
             (case when school_stats_by_years.is_stage_hi = 1 then 'hi' else '__' end ) 
         ) as school_level_simple,
-
         school_stats_by_years.is_rural,
         school_stats_by_years.is_title_i,
         school_stats_by_years.community_type,
-
         schools.school_category,
         schools.school_name,
         schools.school_type,
         case when total_frl_eligible_students / total_students::float > 0.5
             then 1 else 0 
         end as is_high_needs,
-
         schools.last_known_school_year_open,
 
         --school_districts
@@ -103,7 +93,6 @@ combined as (
         -- dates 
         min(schools.created_at) as school_created_at,
         max(schools.updated_at) as school_last_updated_at
-
     from schools
     left join school_stats_by_years
         on schools.school_id = school_stats_by_years.school_id


### PR DESCRIPTION
Reverts code-dot-org/analytics#117


This label is not in line with conventions and has caused downstream issues. 

I also propose we standardize this in a few other places... the column should be `school_year` and the variance in meaning ought to be addressed in the documentation for the model itself.