### PR TITLE
release documentation for ap models

### DIFF
--- a/dbt/models/marts/ap_data/_ap_data_models.yml
+++ b/dbt/models/marts/ap_data/_ap_data_models.yml
@@ -53,7 +53,8 @@ models:
       
       - name: pct_passing_calc
         description: "The calculated percentage of students passing the AP exam (passrate) of this group. It is simply dividing `num_taking / num_passing` values you see in this record"
-
+    config:
+        tags: ['released']
    
 
 
@@ -182,6 +183,8 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: ['source', 'exam_year', 'reporting_group', 'rp_id', 'exam', 'demographic_category', 'demographic_group']
+    config:
+      tags: ['released']
 
   - name: ap_aicode_nces_crosswalk
     description: "This model retrieves the most recent record for each distinct ai_code|nces_id pair from all the AI/NCES crosswalk datasets we've received from the college board. "


### PR DESCRIPTION
# Description

add release tags to documentation for AP data in order for the documentation to appear on the site. 