### PR TITLE
initial hoc models

### DIFF
--- a/dbt/models/marts/hoc/_hoc__models.yml
+++ b/dbt/models/marts/hoc/_hoc__models.yml
@@ -1,0 +1,78 @@
+version: 2
+
+models:
+  - name: fct_hoc_activity
+    description: |
+      commonly tracked hoc metrics by month, school year, and country
+
+    columns:
+      - name: month
+      - name: school_year
+      - name: country
+        description: the country associated with the user's location
+      - name: total_new_teacher_accounts
+        description: the number of new teacher accounts created in the given month
+      - name: total_new_student_accounts
+        description: the number of new student accounts created in the given month
+      - name: total_event_registrations
+        description: the number of HoC events registered in the given month
+      - name: total_hoc_hits
+        description: the number of times an HoC activity was accessed 
+  
+  - name: dim_hoc_activity
+    description: |
+      this model contains 1 row for every URL hit of an HoC activity, regardless of whether the user was signed in   
+          
+      note-- if you'd like to explore signed-in hoc usage, you can use use dim_student_script_level_activity
+
+    columns:
+      - name: hoc_activity_id
+        data_tests: 
+          - not_null
+          - unique
+      - name: started_at
+        description: the timestamp for the URL hit  
+      - name: cal_year
+        description: the calendar year associated with the HoC activity    
+      - name: school_year
+        description: the school year associated with the HoC activity 
+      - name: referer 
+      - name: company 
+      - name: tutorial
+      - name: is_third_party
+        description: 1 if the URL hit was from a third party site with pixel tracking, 0 otherwise
+      - name: city
+        description: the city associated with the user's location
+      - name: country 
+        description: the country associated with the user's location
+      - name: state
+        description: the state associated with the user's location
+      - name: country_code
+      - name: state_code
+    config:
+      tags: ['released']
+ 
+  - name: dim_hoc_event_registrations 
+    columns: 
+      - name: form_id
+        data_tests:
+          - unique
+          - not_null
+      - name: form_kind
+      - name: email
+        description: the email associated with the person registering the event
+      - name: cal_year
+        description: the calendar year associated with the HoC year they are registering for
+      - name: school_year 
+        description: the school year associated with the HoC year they are registering for
+      - name: registered_at 
+        description: timestamp of when the registration form was submitted 
+      - name: event_type
+      - name: email_pref
+      - name: special_event_flag
+      - name: review
+      - name: city
+      - name: state
+      - name: country
+    config:
+      tags: ['released']

--- a/dbt/models/marts/hoc/_hoc__models.yml
+++ b/dbt/models/marts/hoc/_hoc__models.yml
@@ -49,8 +49,8 @@ models:
         description: the state associated with the user's location
       - name: country_code
       - name: state_code
-    config:
-      tags: ['released']
+    # config:
+    #   tags: ['released']
  
   - name: dim_hoc_event_registrations 
     columns: 

--- a/dbt/models/marts/hoc/dim_hoc_activity.sql
+++ b/dbt/models/marts/hoc/dim_hoc_activity.sql
@@ -1,0 +1,30 @@
+with 
+
+hoc_activity as (
+    select * 
+    from {{ ref('stg_pegasus_pii__hoc_activity') }}
+),
+
+school_years as (
+    select * 
+    from {{ ref('int_school_years') }}
+)
+
+select 
+    hoc_activity.hoc_activity_id
+    , hoc_activity.started_at
+    , sy.school_year_int                                                as cal_year 
+    , sy.school_year
+    , hoc_activity.referer
+    , hoc_activity.company
+    , hoc_activity.tutorial
+    , hoc_activity.is_third_party
+    , hoc_activity.city
+    , hoc_activity.country
+    , hoc_activity.state
+    , hoc_activity.state_code
+    , hoc_activity.country_code
+from hoc_activity 
+join school_years                                                       as sy 
+    on hoc_activity.started_at between sy.started_at and sy.ended_at
+

--- a/dbt/models/marts/hoc/dim_hoc_event_registrations.sql
+++ b/dbt/models/marts/hoc/dim_hoc_event_registrations.sql
@@ -1,0 +1,21 @@
+with forms as (
+    select * 
+    from {{ ref('dim_forms') }}
+)
+
+select 
+    form_id
+    , form_kind
+    , email 
+    , hoc_year                                as cal_year
+    , school_year
+    , registered_at
+    , event_type
+    , email_pref
+    , special_event_flag
+    , review
+    , city
+    , state
+    , country
+from forms 
+where form_category = 'hoc'

--- a/dbt/models/marts/hoc/fct_hoc_activity.sql
+++ b/dbt/models/marts/hoc/fct_hoc_activity.sql
@@ -1,0 +1,96 @@
+with 
+
+hoc_activity as (
+    select * 
+    from {{ ref('dim_hoc_activity') }}
+),
+
+school_years as (
+    select * 
+    from {{ ref('int_school_years') }}
+),
+
+forms_hoc as (
+    select * 
+    from {{ ref('dim_hoc_event_registrations') }}
+),
+
+-- form_geos as (
+--     select * 
+--     from {{ ref("stg_pegasus_pii__form_geos") }}
+-- ),
+
+users as (
+    select * 
+    from {{ ref("stg_dashboard__users") }}
+),
+
+user_geos as (
+    select * 
+    from {{ ref("stg_dashboard__user_geos") }}
+),
+
+hoc_hits as (
+    select 
+        date_trunc('month', hoc.started_at)                                                 as hoc_month,
+        hoc.school_year,
+        hoc.country,
+        count(distinct hoc.hoc_activity_id)                                                 as total_hoc_hits 
+       
+    from hoc_activity                                                                       as hoc
+    group by 
+        hoc_month,
+        hoc.school_year,
+        hoc.country
+),
+
+hoc_event_reg as (
+    select 
+        date_trunc('month', forms_hoc.registered_at)                                        as registration_month,
+        forms_hoc.school_year,
+        forms_hoc.country,
+        count(distinct forms_hoc.form_id)                                                   as total_event_registrations
+    from forms_hoc
+    -- left join form_geos 
+    --     on forms_hoc.form_id = form_geos.form_id
+    group by 
+        registration_month,
+        forms_hoc.school_year,
+        forms_hoc.country
+),
+
+new_accounts as (
+    select 
+        date_trunc('month', users.created_at)                                               as created_month, 
+        sy.school_year,
+        user_geos.country,
+        sum(case when user_type = 'teacher' then 1 end)                                     as total_new_teacher_accounts,
+        sum(case when user_type = 'student' then 1 end)                                     as total_new_student_accounts
+    from users
+    left join user_geos 
+        on users.user_id = user_geos.user_id
+    left join school_years                                                                  as sy 
+        on users.created_at between sy.started_at and sy.ended_at
+    where current_sign_in_at is not null
+    group by 
+        created_month,
+        sy.school_year,
+        user_geos.country
+)
+
+select na.created_month                                                                     as month_of,
+       na.school_year,
+       na.country,
+       na.total_new_teacher_accounts,
+       na.total_new_student_accounts,
+       reg.total_event_registrations,
+       hh.total_hoc_hits
+from new_accounts na
+left join hoc_event_reg reg 
+  on na.created_month = reg.registration_month
+  and na.school_year = reg.school_year
+  and na.country = reg.country
+left join hoc_hits hh
+  on hh.hoc_month = reg.registration_month
+  and hh.school_year = reg.school_year
+  and hh.country = reg.country

--- a/dbt/models/marts/misc/dim_forms.sql
+++ b/dbt/models/marts/misc/dim_forms.sql
@@ -9,11 +9,17 @@ form_geos as (
     from {{ ref('stg_pegasus_pii__form_geos') }}
 ),
 
+school_years as (
+    select * 
+    from {{ ref('int_school_years') }}
+),
+
 combined as (
     select 
         forms.form_id,
         forms.form_category,
         forms.hoc_year,
+        sy.school_year, 
         forms.email,
         forms.name,
         forms.form_kind,
@@ -27,6 +33,9 @@ combined as (
         forms.user_id,
         forms.parent_id,
         forms.location_country_code,
+        forms.event_type,
+        forms.email_pref,
+        forms.special_event_flag,
         coalesce(forms.city,form_geos.city)                     as city,
         coalesce(forms.state,form_geos.state)                   as state,
         coalesce(forms.country,form_geos.country)               as country,
@@ -35,7 +44,9 @@ combined as (
     from forms 
     left join form_geos 
         on forms.form_id = form_geos.form_id
-    {{ dbt_utils.group_by(19) }}
+    left join school_years                                      as sy
+        on forms.hoc_year = sy.school_year_int
+    {{ dbt_utils.group_by(23) }}
 )
 
 select * 

--- a/dbt/models/staging/pegasus_pii/stg_pegasus_pii__forms.sql
+++ b/dbt/models/staging/pegasus_pii/stg_pegasus_pii__forms.sql
@@ -34,11 +34,12 @@ forms as (
         location_country_code,
         -- form_data_text,  
         -- processed_data_text,
-        nullif(json_extract_path_text(processed_data_text, 'location_city_s', true), '')      as city,
-        nullif(json_extract_path_text(processed_data_text, 'location_state_s', true), '')     as state,
-        nullif(json_extract_path_text(processed_data_text, 'location_country_s', true), '')   as country,
-        nullif(json_extract_path_text(form_data_text, 'event_type_s', true), '')              as event_type,
-        nullif(json_extract_path_text(form_data_text, 'email_preference_opt_in_s', true), '') as email_pref
+        lower(nullif(json_extract_path_text(processed_data_text, 'location_city_s', true), ''))      as city,
+        lower(nullif(json_extract_path_text(processed_data_text, 'location_state_s', true), ''))     as state,
+        lower(nullif(json_extract_path_text(processed_data_text, 'location_country_s', true), ''))   as country,
+        lower(nullif(json_extract_path_text(form_data_text, 'event_type_s', true), ''))              as event_type,
+        nullif(json_extract_path_text(form_data_text, 'email_preference_opt_in_s', true), '')        as email_pref,
+        nullif(json_extract_path_text(form_data_text, 'special_event_flag_b', true), '')             as special_event_flag
     from {{ ref('base_pegasus_pii__forms') }}
 )
 


### PR DESCRIPTION
# Description

This PR builds and provides documentation for 2 initial HoC models:
1. dim_hoc_event_registrations (all registrations of HoC activities collected through our form) 
2. dim_hoc_activity (all URL hits to an HoC activity, including pixel tracking with 3rd parties)

The model, fct_hoc_activity is a prototype of a fact table that might be useful to the Marketing team in quickly accessing HoC metrics. However, this model remains unreleased as there needs to be more thought around impact metrics before releasing. (e.g. measuring HoC conversions). Does not need review right now. 

Open questions:
- was the pixel tracking issue with one of our 3rd party providers resolved? If not, how should we update this model?
- in the past, there have been some manual additions from some 3rd party reported numbers that we have incorporated into the hoc_activity data. Will this continue? Does it make a meaningful impact to our overall HoC numbers to incorporate it? If it needs to be incorporated, how best to do that while preserving the model structure? 

## Links

Jira ticket(s): [DATAOPS-913](https://codedotorg.atlassian.net/jira/software/projects/DATAOPS/boards/72/backlog?selectedIssue=DATAOPS-913)
