### PR TITLE
fix discrepancy with pegasus source table

### DIFF
--- a/dbt/models/marts/misc/dim_forms.sql
+++ b/dbt/models/marts/misc/dim_forms.sql
@@ -36,9 +36,9 @@ combined as (
         forms.event_type,
         forms.email_pref,
         forms.special_event_flag,
-        coalesce(forms.city,form_geos.city)                     as city,
-        coalesce(forms.state,form_geos.state)                   as state,
-        coalesce(forms.country,form_geos.country)               as country,
+        lower(coalesce(forms.city,form_geos.city))              as city,
+        lower(coalesce(forms.state,form_geos.state))            as state,
+        lower(coalesce(forms.country,form_geos.country))        as country,
         max(forms.created_at)                                   as registered_at,
         max(coalesce(forms.updated_at,forms.created_at))        as last_updated_at
     from forms 

--- a/dbt/models/staging/pegasus_pii/base/base_pegasus_pii__hoc_activity.sql
+++ b/dbt/models/staging/pegasus_pii/base/base_pegasus_pii__hoc_activity.sql
@@ -12,6 +12,7 @@ renamed as (
         tutorial,
         started_at,
         pixel_started_at,
+        pixel_finished_at,
         country_code,
         state_code,
         city,

--- a/dbt/models/staging/pegasus_pii/stg_pegasus_pii__hoc_activity.sql
+++ b/dbt/models/staging/pegasus_pii/stg_pegasus_pii__hoc_activity.sql
@@ -12,7 +12,7 @@ hoc_activity as (
         referer,
         company,
         tutorial,
-        coalesce(started_at, pixel_started_at)                      as started_at,
+        coalesce(started_at, pixel_started_at, pixel_finished_at)   as started_at,
         case when pixel_started_at is not null then 1 else 0 end    as is_third_party,
         country_code,
         state_code,

--- a/dbt/models/staging/pegasus_pii/stg_pegasus_pii__hoc_activity.sql
+++ b/dbt/models/staging/pegasus_pii/stg_pegasus_pii__hoc_activity.sql
@@ -22,7 +22,7 @@ hoc_activity as (
     from {{ ref("base_pegasus_pii__hoc_activity") }}
     {% if is_incremental() %}
 
-    where started_at > (select max(started_at) from {{ this }} )
+    where coalesce(started_at, pixel_started_at, pixel_finished_at) > (select max(started_at) from {{ this }} )
     
     {% endif %}
 )


### PR DESCRIPTION

# Description

some rows in dim_hoc_activity only have pixel_ended_at, but not pixel_started_at, which when we join with school_years, gets excluded from the resulting model. This is a PR to account for those rows. 

## Links

Jira ticket(s): [DATAOPS-913](https://codedotorg.atlassian.net/jira/software/projects/DATAOPS/boards/72/backlog?selectedIssue=DATAOPS-913)

