### PR TITLE
allow 0s in district metrics for inactive districts

### DIFF
--- a/dbt/models/marts/districts/dim_district_status.sql
+++ b/dbt/models/marts/districts/dim_district_status.sql
@@ -107,8 +107,8 @@ active_status_simple as (
         end                                                                 as is_active,
         started_districts.district_started_at,
         started_districts.active_courses,
-        active_district_stats.num_active_teachers,
-        active_district_stats.num_active_schools
+        coalesce(active_district_stats.num_active_teachers, 0)              as num_active_teachers,
+        coalesce(active_district_stats.num_active_schools, 0)               as num_active_schools
     from all_districts_sy 
     left join started_districts
         on started_districts.school_district_id = all_districts_sy.school_district_id 


### PR DESCRIPTION
Our district program wants to measure impact of enrollment-- in order to do that, we need to be able to average # teacher/schools that are active in districts before and after they enroll, which requires inactive districts to count as 0, as opposed to null. 