### PR TITLE
change active courses to more evergreen logic

### DIFF
--- a/dbt/models/marts/courses/dim_course_structure.sql
+++ b/dbt/models/marts/courses/dim_course_structure.sql
@@ -80,10 +80,14 @@ combined as (
                 coalesce(
                     ug.instruction_type,
                     sc.instruction_type
-                ) = 'self_paced' 
+                ) = 'self_paced'
+                and coalesce(
+                    ug.participant_audience,
+                    sc.participant_audience
+                )  = 'teacher'
             then 1 
             else 0 
-        end                                                             as is_self_paced,    
+        end                                                             as is_self_paced_pd,    
         case 
             when 
                 coalesce(
@@ -102,6 +106,23 @@ combined as (
             then 1 
             else 0 
         end                                                             as is_pd_content,
+
+        case 
+            when 
+                coalesce(
+                    ug.participant_audience,
+                    sc.participant_audience
+                )  = 'student'
+                and sc.published_state in (
+                    'stable',
+                    'preview',
+                    'beta')
+                and sc.course_name not in (
+                    'hoc', 
+                    'other')                                                             
+            then 1 
+            else 0 
+        end                                                             as is_active_student_course,
 
         -- scripts
         sl.script_id,

--- a/dbt/models/marts/courses/dim_course_structure.sql
+++ b/dbt/models/marts/courses/dim_course_structure.sql
@@ -72,7 +72,6 @@ combined as (
         ug.unit_group_id                                                as course_id,
         ug.unit_group_name                                              as course_name_full,
         sc.course_name,
-        sc.is_active_student_course,
 
         --flags
         case 

--- a/dbt/models/staging/dashboard/stg_dashboard__scripts.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__scripts.sql
@@ -22,30 +22,31 @@ renamed as (
         case 
             when json_extract_path_text(
                 properties, 
-                'curriculum_umbrella') = ''                         then 'other'
+                'curriculum_umbrella') = ''                         
+            then 'other'
             else lower(
                 json_extract_path_text(
                     properties, 
                     'curriculum_umbrella',
                 true))
-        end as course_name,
+        end                                                                 as course_name,
         
         json_extract_path_text(
             properties, 
-            'supported_locales')    as supported_locales,
+            'supported_locales')                                            as supported_locales,
         
         json_extract_path_text(
             properties,
-            'version_year')         as version_year,
+            'version_year')                                                 as version_year,
         
         json_extract_path_text(
             properties,
-            'is_course')            as is_standalone,
+            'is_course')                                                    as is_standalone,
         
         regexp_replace(
             script_name,
             '((-)+\\d{4})',
-            '')                     as unit,
+            '')                                                             as unit,
 
         created_at,
         updated_at
@@ -54,16 +55,10 @@ renamed as (
 select 
     *
     , case 
-        when course_name in (
-            'csc',
-            'csf', 
-            'csd', 
-            'csa', 
-            'csp', 
-            'ai', 
-            'foundations of cs'
-        )
+        when participant_audience = 'student'
+            and published_state in ('stable', 'preview', 'beta')
+            and course_name not in ('hoc', 'other')                                                             
         then 1 
         else 0 
-    end                                                             as is_active_student_course
+    end                                                                     as is_active_student_course
 from renamed

--- a/dbt/models/staging/dashboard/stg_dashboard__scripts.sql
+++ b/dbt/models/staging/dashboard/stg_dashboard__scripts.sql
@@ -54,11 +54,4 @@ renamed as (
     
 select 
     *
-    , case 
-        when participant_audience = 'student'
-            and published_state in ('stable', 'preview', 'beta')
-            and course_name not in ('hoc', 'other')                                                             
-        then 1 
-        else 0 
-    end                                                                     as is_active_student_course
 from renamed


### PR DESCRIPTION
# Description

This PR is a small change to the definition of "is_active_student_course" in `stg_dashboard__scripts` and moves the logic to `dim_course_structure` to be consistent with defining other flags and to make it more evergreen with additions of new courses in the future. 