### PR TITLE
changes to dim_cs_access

### DIFF
--- a/dbt/models/marts/access_report/_access_report_models.yml
+++ b/dbt/models/marts/access_report/_access_report_models.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: dim_cs_access
     description: |
-      This model contains information about whether or not a school has a computer science offering. There is one row per school/ access report year. Only public and charter schools are included. 
+      This model contains information about whether or not a school has a computer science offering. There is one row per school/ access report year. Only public/charter high schools are included. 
 
       **note**: this data is entirely from external datasets and does not contain any information regarding code.org usage. 
     columns:

--- a/dbt/models/marts/access_report/_access_report_models.yml
+++ b/dbt/models/marts/access_report/_access_report_models.yml
@@ -3,8 +3,7 @@ version: 2
 models:
   - name: dim_cs_access
     description: |
-      This model contains information about whether or not a school has a computer science offering. There is one row per school/ access report year.
-      There is additional information about the source(s) from which we gained the data about that school from. 
+      This model contains information about whether or not a school has a computer science offering. There is one row per school/ access report year. Only public and charter schools are included. 
 
       **note**: this data is entirely from external datasets and does not contain any information regarding code.org usage. 
     columns:
@@ -43,55 +42,7 @@ models:
       - name: school_type
         description: "The type of school. Possible values are 'public' and 'charter'."
 
-      - name: doe
-        description: "Indicates if the Department of Education provides data. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: provider_ib
-        description: "Indicates if the school offers International Baccalaureate programs. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: provider_ap
-        description: "Indicates if the school offers Advanced Placement programs. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: provider_teals
-        description: "Indicates if the school offers TEALS programs. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: provider_bootup
-        description: "Indicates if the school offers BootUp programs. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: provider_cambridge
-        description: "Indicates if the school offers Cambridge programs. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: provider_cyber
-        description: "Indicates if the school offers Cyber programs. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: all_providers
-        description: "Indicates if the school offers all listed providers. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: survey
-        description: "Indicates if data is provided by a survey. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: staff_entry
-        description: "Indicates if data is provided by staff entry. Possible values are 'Y' for Yes and 'N' for No."
-
-      - name: last_year
-        description: "Indicates if data is from last year. Possible values are 'Y' for Yes, 'N' for No, 'E' for Exclude, 'HN' for Hybrid No, 'HY' for Hybrid Yes."
-        data_tests:
-          - accepted_values:
-              values: ["Y", "N", "E", "HN", "HY"]
-      - name: override
-        description: "Indicates if data is an override. Possible values are 'Y' for Yes, 'N' for No, 'E' for Exclude, 'HN' for Hybrid No, 'HY' for Hybrid Yes."
-        data_tests:
-          - accepted_values:
-              values: ["Y", "N", "E", "HN", "HY"]
-
-      - name: teaches_cs_final
-        description: "Indicates the final decision on whether the school teaches computer science. Possible values are 'Y' for Yes, 'N' for No, 'flag', 'unknown'."
-        data_tests:
-          - accepted_values:
-              values: ["Y", "N", "HY", "HN", "E", "flag", "unknown"]
-      - name: filenames
-        description: "The name of the file from which the data was sourced."
-      - name: notes
-        description: "Additional notes or comments regarding the data entry."
+      - name: teaches_cs
+        description: 1 if the school has been verified to be teaching CS (either in the current year or last school year)
     config:
       tags: ['released']

--- a/dbt/models/marts/access_report/dim_cs_access.sql
+++ b/dbt/models/marts/access_report/dim_cs_access.sql
@@ -1,8 +1,19 @@
 with 
 
 review_table as (
-    select * 
+    select 
+        access_report_year
+        , nces_school_id
+        , state
+        , school_name
+        , grade_levels
+        , school_type 
+        , case 
+            when teaches_cs_final in ('HY', 'Y') then 1 
+            else 0 
+        end                                                     as teaches_cs
     from {{ ref('stg_external_datasets__access_report_review_table') }}
+    
 )
 
 select * 

--- a/dbt/models/marts/access_report/dim_cs_access.sql
+++ b/dbt/models/marts/access_report/dim_cs_access.sql
@@ -13,6 +13,7 @@ review_table as (
             else 0 
         end                                                     as teaches_cs
     from {{ ref('stg_external_datasets__access_report_review_table') }}
+    where access_report_year != '2024'
     
 )
 

--- a/dbt/models/staging/external_datasets/stg_external_datasets__access_report_review_table.sql
+++ b/dbt/models/staging/external_datasets/stg_external_datasets__access_report_review_table.sql
@@ -21,3 +21,7 @@ with all_data as (
 )
 select *
 from all_data
+where state not in ('AS', 'GU', 'MP', 'PR', 'VI') -- exclude territories
+and teaches_cs_final not in ('unknown', 'E', 'flag') -- exclude schools with unknown CS status
+and grade_levels != '______' -- exclude schools with no grade levels
+and school_type in ('public', 'charter')

--- a/dbt/models/staging/external_datasets/stg_external_datasets__access_report_review_table.sql
+++ b/dbt/models/staging/external_datasets/stg_external_datasets__access_report_review_table.sql
@@ -23,5 +23,5 @@ select *
 from all_data
 where state not in ('AS', 'GU', 'MP', 'PR', 'VI') -- exclude territories
 and teaches_cs_final not in ('unknown', 'E', 'flag') -- exclude schools with unknown CS status
-and grade_levels != '______' -- exclude schools with no grade levels
+and grade_levels like '%hi%' -- access report is only about high schools
 and school_type in ('public', 'charter')


### PR DESCRIPTION

# Description

this PR contains some filtering/column changes to dim_cs_access based on requests from Hannah W. 

Namely, it: 
- does not include columns that are not useful to end users (source and notes columns) 
- excludes territories 
- excludes schools with no grade level data 
- excludes private schools 
- creates a binary column for cs access, grouping HY and Y 