### PR TITLE
make 2024 access report data available

### DIFF
--- a/dbt/models/marts/access_report/dim_cs_access.sql
+++ b/dbt/models/marts/access_report/dim_cs_access.sql
@@ -13,7 +13,6 @@ review_table as (
             else 0 
         end                                                     as teaches_cs
     from {{ ref('stg_external_datasets__access_report_review_table') }}
-    where access_report_year != '2024'
     
 )
 


### PR DESCRIPTION
remove filter we previously had to filter out 2024 access report data, since 2024 is now updated. 