### PR TITLE
adding enrolled_at and updating seed file

### DIFF
--- a/dbt/data/seed_districts_enrolled.csv
+++ b/dbt/data/seed_districts_enrolled.csv
@@ -1,334 +1,503 @@
-company_name,state,company_owner,company_type,month_closed,district_id
-Adrian Public Schools District 511,MN,Andy Teipen,District-Public,2024-07-01,2702730
-Alameda Unified School District,CA,Nikki Navta,District-Public,2024-08-01,601770
-Alexander 2 School District,ND,Carrie Morrison,District-Public,2024-06-01,3801760
-Alleghany Highlands Public Schools,VA,Caison Bridger,District-Public,2024-06-01,5100152
-Allen Public Schools,OK,Carrie Morrison,District-Public,2024-07-01,4002760
-Alpine Academy,NV,Carrie Morrison,District-Private,2024-08-01,320000100800
-Alta Loma School District,CA,Nikki Navta,District-Public,2024-05-01,602160
-Ambition Preparatory Charter,MS,Tonya Davis,District-Charter,2024-03-01,2800197
-American Falls School District,ID,Carrie Morrison,District-Public,2024-05-01,1600060
-Anderson County School District,TN,Caison Bridger,District-Public,2024-06-01,4700090
-Arizona Connections Academy Charter School Inc.,AZ,Carrie Morrison,District-Charter,2024-05-01,40042703160
-Arlington Central School District,NY,Caison Bridger,District-Public,2024-05-01,3603270
-Ascension Parish School Board,LA,Tonya Davis,District-Public,2024-03-01,2200090
-Bald Knob School District,AR,Tonya Davis,District-Public,2024-05-01,502700
-Balsz Elementary School District,AZ,Carrie Morrison,District-Public,2024-04-01,401050
-Baltimore City Public Schools,MD,Caison Bridger,District-Public,2024-06-01,2400090
-Barnegat Township School District,NJ,Caison Bridger,District-Public,2024-05-01,3416470
-BASIS Flagstaff,AZ,Carrie Morrison,District-Charter,2024-08-01,40083103196
-Battle Creek Public Schools,NE,Andy Teipen,District-Public,2024-05-01,3103540
-Bayonne Board of Education,NJ,Caison Bridger,District-Public,2024-05-01,3401260
-Belle Plaine Public Schools,MN,Andy Teipen,District-Public,2024-05-01,2704050
-Berlin Public Schools,CT,Caison Bridger,District-Public,2024-04-01,900210
-Berlin-Boylston Regional School District,MA,Caison Bridger,District-Public,2024-05-01,2502580
-Bessemer Area Schools,MI,Andy Teipen,District-Public,2024-07-01,2600006
-Bethel School District,CT,Caison Bridger,District-Public,2024-04-01,900270
-Blaine County School District,ID,Carrie Morrison,District-Public,2024-05-01,1600300
-Bloomfield Public Schools,NJ,Caison Bridger,District-Public,2024-03-01,3401830
-Blue Valley Unified School District 229,KS,Andy Teipen,District-Public,2024-05-01,2012000
-Bossier Parish Schools,LA,Tonya Davis,District-Public,2024-04-01,2200270
-Bourne Public Schools,MA,Caison Bridger,District-Public,2024-05-01,2502820
-Bradley County Schools,TN,Caison Bridger,District-Public,2024-05-01,4700330
-Brandywine School District,DE,Caison Bridger,District-Public,2024-03-01,1001240
-Bristol Tennessee City School District,TN,Caison Bridger,District-Public,2024-05-01,4700360
-Brooklyn Center Community Schools,MN,Andy Teipen,District-Public,2024-03-01,2706240
-Caldwell School District,ID,Carrie Morrison,District-Public,2024-05-01,1600510
-Calvary Academy,IL,Andy Teipen,District-Private,2024-08-01,1647828
-Canutillo Independent School District,TX,Tonya Davis,District-Public,2024-05-01,4812780
-Carbon Learning Achievement School,PA,Andy Teipen,District-Public,2024-03-01,4289310
-Carlinville CUSD#1,IL,Andy Teipen,District-Public,2024-03-01,1708430
-Carteret County Public Schools,NC,Caison Bridger,District-Public,2024-08-01,3700630
-Catalyst Public Schools,WA,Carrie Morrison,District-Public,2024-05-01,5300347
-Cavalier 6 School District,ND,Carrie Morrison,District-Public,2024-03-01,3800018
-Cedar Rapids Community School District,IA,Andy Teipen,District-Public,2024-03-01,1906540
-Center Grove Community Schools,IN,Andy Teipen,District-Public,2024-03-01,1801440
-Charles County Public Schools,MD,Caison Bridger,District-Public,2024-07-01,2400270
-Charleston County School District,SC,Tonya Davis,District-Public,2024-05-01,4501440
-Cherokee County Schools,NC,Caison Bridger,District-Public,2024-08-01,3700780
-Chippewa Valley Schools,MI,Andy Teipen,District-Public,2024-03-01,2609570
-City School District of New Rochelle,NY,Caison Bridger,District-Public,2024-04-01,3620490
-City Schools of Decatur,GA,Tonya Davis,District-Public,2024-04-01,1301680
-Clarendon County School District,SC,Tonya Davis,District-Public,2024-05-01,4501770
-Clark County School District,NV,Carrie Morrison,District-Public,2024-03-01,3200060
-Clarkston Community Schools,MI,Andy Teipen,District-Public,2024-08-01,2609900
-Clearview Local School District,OH,Andy Teipen,District-Public,2024-03-01,3904813
-Cleveland Metropolitan School District,OH,Andy Teipen,District-Public,2024-03-01,3904378
-Clinch County School District,GA,Tonya Davis,District-Public,2024-03-01,1301260
-Clover Park School District,WA,Carrie Morrison,District-Public,2024-05-01,5301410
-Clovis Unified School District,CA,Nikki Navta,District-Public,2024-03-01,609030
-Cole County R-V School District,MO,Andy Teipen,District-Public,2024-04-01,2911550
-Coleman Public Schools,OK,Carrie Morrison,District-Public,2024-07-01,4008310
-Columbia Union School District,CA,Nikki Navta,District-Public,2024-09-01,609480
-Columbus County Schools,NC,Caison Bridger,District-Public,2024-03-01,3700960
-Converse County School District #2,WY,Carrie Morrison,District-Public,2024-04-01,5602150
-Cornell School District,WI,Andy Teipen,District-Public,2024-04-01,5502880
-Corona-Norco Unified School District,CA,Nikki Navta,District-Public,2024-07-01,609850
-Cowan Community School Corporation,IN,Andy Teipen,District-Public,2024-04-01,1807020
-Cozad Community Schools,NE,Andy Teipen,District-Public,2024-04-01,3105460
-Crosspoint Christian School,WA,Carrie Morrison,District-Religious,2024-07-01,A1192099
-Cuba Independent Schools,NM,Carrie Morrison,District-Public,2024-05-01,3500660
-Currituck County School District,NC,Caison Bridger,District-Public,2024-03-01,3701080
-Dakota Boys and Girls Ranch,ND,Carrie Morrison,District-Public,2024-04-01,3800040
-Danville Community School Corporation,IN,Andy Teipen,District-Public,2024-07-01,1802550
-Darlington County School District,SC,Tonya Davis,District-Public,2024-05-01,4501860
-Davie County Schools,NC,Caison Bridger,District-Public,2024-05-01,3701170
-Daviess County Public Schools,KY,Andy Teipen,District-Public,2024-03-01,2101470
-Decatur County School District,GA,Tonya Davis,District-Public,2024-03-01,1301710
-Deer Valley Unified School District,AZ,Carrie Morrison,District-Public,2024-03-01,407750
-Denison Community Schools,IA,Andy Teipen,District-Public,2024-03-01,1908910
-Denver Public Schools,CO,Carrie Morrison,District-Public,2024-03-01,803360
-Derry Cooperative School District,NH,Caison Bridger,District-Public,2024-04-01,3302610
-Detroit Public Schools Community District,MI,Andy Teipen,District-Public,2024-03-01,2601103
-Dodgeville Schools,WI,Andy Teipen,District-Public,2024-05-01,5503690
-Dubuque Community School District,IA,Andy Teipen,District-Public,2024-03-01,1909480
-Dunellen Public Schools,NJ,Caison Bridger,District-Public,2024-05-01,3404020
-Duplin County Schools,NC,Caison Bridger,District-Public,2024-06-01,3701200
-Duval County Public Schools,FL,Tonya Davis,District-Public,2024-04-01,1200480
-East Hanover Township School District,NJ,Caison Bridger,District-Public,2024-05-01,3404170
-Eastern Camden County Regional School District,NJ,Caison Bridger,District-Public,2024-05-01,3404380
-Effingham Community Unit School District 40,IL,Andy Teipen,District-Public,2024-03-01,1713560
-Effingham County School District,GA,Tonya Davis,District-Public,2024-04-01,1301980
-Eleanor Kolitz Hebrew Language Academy,TX,Tonya Davis,District-Religious,2024-05-01,480143513053
-Elko County School District,NV,Carrie Morrison,District-Public,2024-03-01,3200120
-Elmbrook School District,WI,Andy Teipen,District-Public,2024-05-01,5501770
-Epic Charter Schools,OK,Carrie Morrison,District-Charter,2024-04-01,400077702789
-Estancia Municipal School District,NM,Carrie Morrison,District-Public,2024-04-01,3500930
-Evanston Skokie CCSD 65,IL,Andy Teipen,District-Public,2024-06-01,1714460
-Fayette County Schools,WV,Andy Teipen,District-Public,2024-03-01,5400300
-Ferguson-Florissant School District,MO,Andy Teipen,District-Public,2024-04-01,2912010
-Finley-Sharon 19 School District,ND,Carrie Morrison,District-Public,2024-03-01,3806910
-Fort Bragg Unified School District,CA,Nikki Navta,District-Public,2024-03-01,614070
-Fort Wayne Community Schools,IN,Andy Teipen,District-Public,2024-06-01,1803630
-Franklin Township Community School Corporation,IN,Andy Teipen,District-Public,2024-03-01,1803750
-"Frederick County Public Schools, VIRGINIA",VA,Caison Bridger,District-Public,2024-05-01,5101470
-Galena City School District,AK,Carrie Morrison,District-Public,2024-05-01,200130
-Gananda Central School District,NY,Caison Bridger,District-Public,2024-05-01,3611740
-Garden Grove Unified School District,CA,Nikki Navta,District-Public,2024-03-01,614880
-Garrett County Public Schools,MD,Caison Bridger,District-Public,2024-07-01,2400360
-Germantown Municipal School District,TN,Caison Bridger,District-Public,2024-04-01,4700151
-Gibraltar Area School District,WI,Andy Teipen,District-Public,2024-07-01,5505220
-Glen Rock Public Schools,NJ,Caison Bridger,District-Public,2024-05-01,3405970
-Granby Public Schools,MA,Caison Bridger,District-Public,2024-05-01,2505400
-Grand Rapids Public Schools,MI,Andy Teipen,District-Public,2024-07-01,2616440
-Grayslake CCSD 46,IL,Andy Teipen,District-Public,2024-03-01,1717520
-Greece Central schools,NY,Caison Bridger,District-Public,2024-07-01,3612630
-Gretna Public Schools,NE,Andy Teipen,District-Public,2024-07-01,3171220
-Griffith Public Schools,IN,Andy Teipen,District-Public,2024-04-01,1804170
-Guilford County Schools,NC,Caison Bridger,District-Public,2024-03-01,3701920
-Haddon Heights School District,NJ,Caison Bridger,District-Public,2024-05-01,3406330
-Hanover Community School Corporation,IN,Andy Teipen,District-Public,2024-03-01,1804350
-Hanover Park Regional High School District,NJ,Caison Bridger,District-Public,2024-05-01,3406660
-Hastings Public Schools,NE,Andy Teipen,District-Public,2024-04-01,3171580
-Hawaii State Department of Education,HI,Carrie Morrison,District-Public,2024-03-01,1500030
-Hay Springs Public School District 3,NE,Andy Teipen,District-Public,2024-07-01,3171610
-Hazen Public Schools,ND,Carrie Morrison,District-Public,2024-04-01,3800031
-Herscher Community Unit School District #2,IL,Andy Teipen,District-Public,2024-05-01,1718840
-Hershey Public Schools,NE,Andy Teipen,District-Public,2024-05-01,3171820
-Hickman County Schools,TN,Caison Bridger,District-Public,2024-04-01,4701860
-Highland Falls Fort Montgomery CSD,NY,Caison Bridger,District-Public,2024-03-01,3614430
-Hillsboro Public School District,ND,Carrie Morrison,District-Public,2024-03-01,3809570
-Hillsborough Township Public Schools,NJ,Caison Bridger,District-Public,2024-05-01,3407230
-Hoke County Schools,NC,Caison Bridger,District-Public,2024-07-01,3702250
-Holy Family Catholic Schools,IA,Andy Teipen,District-Religious,2024-03-01,A1701794
-Hope Christian Academy,ND,Carrie Morrison,District-Religious,2024-06-01,1924575
-Horizon Science Academy Cleveland High School,OH,Andy Teipen,District-Public,2024-03-01,390004002939
-Humble Independent School District,TX,Tonya Davis,District-Public,2024-03-01,4823910
-Humboldt County School District,NV,Carrie Morrison,District-Public,2024-03-01,3200210
-Hydaburg City School District,AK,Carrie Morrison,District-Public,2024-03-01,200330
-Indian Hill Exempted Village School District,OH,Andy Teipen,District-Public,2024-04-01,3904543
-Indiana Math & Science Academy North,IN,Andy Teipen,District-Charter,2024-04-01,1800067
-Iowa City Community School District,IA,Andy Teipen,District-Public,2024-05-01,1914700
-Ipswich Public Schools,MA,Caison Bridger,District-Public,2024-06-01,2506480
-Jacksboro Independent School District,TX,Tonya Davis,District-Public,2024-04-01,4824530
-Jeff Davis County School District,GA,Tonya Davis,District-Public,2024-03-01,1303000
-Jefferson County Public Schools (KY),KY,Andy Teipen,District-Public,2024-04-01,2102990
-Jennings County Schools,IN,Andy Teipen,District-Public,2024-03-01,1805190
-Johnston County Public Schools,NC,Caison Bridger,District-Public,2024-04-01,3702370
-Kasson-Mantorville Schools,MN,Andy Teipen,District-Public,2024-03-01,2716980
-Kearsley Community Schools,MI,Andy Teipen,District-Public,2024-05-01,2620070
-Kenai Peninsula Borough School District,AK,Carrie Morrison,District-Public,2024-03-01,200390
-Kenmare 28 School District,ND,Carrie Morrison,District-Public,2024-04-01,3810180
-Kindred 2 School District,ND,Carrie Morrison,District-Public,2024-06-01,3800025
-Lake Shore Central School District,NY,Caison Bridger,District-Public,2024-03-01,3616560
-Lake Shore Public Schools,MI,Andy Teipen,District-Public,2024-03-01,2632670
-Lake Washington School District,WA,Carrie Morrison,District-Public,2024-04-01,5304230
-Lansing School District,MI,Andy Teipen,District-Public,2024-05-01,2621150
-Las Cruces Public Schools,NM,Carrie Morrison,District-Public,2024-04-01,3501500
-Lawrenceburg Community School Corporation,IN,Andy Teipen,District-Public,2024-03-01,1805700
-Leap Academy University Charter School,NJ,Caison Bridger,District-Charter,2024-09-01,3400078
-Leonia School District,NJ,Caison Bridger,District-Public,2024-05-01,3408520
-Lewiston Independent School District #1,ID,Carrie Morrison,District-Public,2024-05-01,1601860
-Lexington County School District One,SC,Tonya Davis,District-Public,2024-07-01,4502700
-Lexington Independent School District,TX,Tonya Davis,District-Public,2024-05-01,4827330
-Liberty-Perry Community School District,IN,Andy Teipen,District-Public,2024-08-01,1805880
-Lincoln County School District,NV,Carrie Morrison,District-Public,2024-03-01,3200270
-Lincoln Public Schools,NE,Andy Teipen,District-Public,2024-06-01,3172840
-Linton-Stockton School Corporation,IN,Andy Teipen,District-Public,2024-08-01,1805910
-Lopatcong Township School District,NJ,Caison Bridger,District-Public,2024-06-01,3409000
-Los Angeles Unified School District,CA,Nikki Navta,District-Public,2024-06-01,622710
-Los Gatos Union School District,CA,Nikki Navta,District-Public,2024-04-01,622830
-Loudoun County Public Schools,VA,Caison Bridger,District-Public,2024-05-01,5102250
-Louisville Municipal School District,MS,Tonya Davis,District-Public,2024-05-01,2802700
-Lubbock-Cooper ISD,TX,Tonya Davis,District-Public,2024-05-01,4815180
-Manhattan Charter School,NY,Caison Bridger,District-Charter,2024-05-01,360013705766
-Mankato Area Public Schools,MN,Andy Teipen,District-Public,2024-03-01,2718780
-Marshall Public Schools,WI,Andy Teipen,District-Public,2024-05-01,5508790
-Martin County Schools (NC),NC,Caison Bridger,District-Public,2024-04-01,3702880
-Marysville School District,WA,Carrie Morrison,District-Public,2024-06-01,5304860
-Matanuska-Susitna Borough School District,AK,Carrie Morrison,District-Public,2024-04-01,200510
-May-Port CG School District,ND,Carrie Morrison,District-Public,2024-03-01,3800041
-Maynard Public Schools,MA,Caison Bridger,District-Public,2024-05-01,2507500
-McKenzie Special School District,TN,Caison Bridger,District-Public,2024-05-01,4702790
-Meade USD 226,KS,Andy Teipen,District-Public,2024-08-01,2009420
-Melrose Public Schools,MA,Caison Bridger,District-Public,2024-05-01,2507620
-Metro Nashville Public Schools,TN,Caison Bridger,District-Public,2024-08-01,4703180
-Mid-Prairie Community Schools,IA,Andy Teipen,District-Public,2024-03-01,1919140
-Midway Public School #128,ND,Carrie Morrison,District-Public,2024-05-01,3812920
-Miller R-II Schools,MO,Andy Teipen,District-Public,2024-07-01,2921000
-Monroe County Community School,IN,Andy Teipen,District-Public,2024-03-01,1800630
-Monroe County Schools,WV,Andy Teipen,District-Public,2024-04-01,5700000
-Montclair Public Schools,NJ,Caison Bridger,District-Public,2024-05-01,3410560
-Montebello Unified School District,CA,Nikki Navta,District-Public,2024-05-01,625470
-Monterey Peninsula Unified School District,CA,Nikki Navta,District-Public,2024-05-01,625530
-Montgomery Public Schools,AL,Tonya Davis,District-Public,2024-03-01,102430
-Mott-Regent Public Schools,ND,Carrie Morrison,District-Public,2024-04-01,3800046
-Mount Markham Central School District,NY,Caison Bridger,District-Public,2024-04-01,3630930
-Mountain Iron-Buhl,MN,Andy Teipen,District-Public,2024-05-01,2700001
-MSD Mount Vernon,IN,Andy Teipen,District-Public,2024-04-01,1807290
-Mt Pleasant School District #4,ND,Carrie Morrison,District-Public,2024-04-01,3813400
-Muskegon Public Schools,MI,Andy Teipen,District-Public,2024-07-01,2624840
-Napoleon 2 School District,ND,Carrie Morrison,District-Public,2024-04-01,3813510
-Natick Public Schools,MA,Caison Bridger,District-Public,2024-06-01,2508340
-National Heritage Academies,MI,Andy Teipen,District-Public,2024-03-01,1800042
-New Britain School District,CT,Caison Bridger,District-Public,2024-03-01,902670
-New Brunswick School District,NJ,Caison Bridger,District-Public,2024-07-01,3411220
-New Canaan Public Schools,CT,Caison Bridger,District-Public,2024-06-01,902700
-New England Public School,ND,Carrie Morrison,District-Public,2024-06-01,3800027
-New Miami Local,OH,Andy Teipen,District-Public,2024-04-01,3904613
-New Visions Charter Network IV,NY,Caison Bridger,District-Charter,2024-04-01,360113606549
-Newark Board of Education,NJ,Caison Bridger,District-Public,2024-03-01,3411340
-Newport Special School District,AR,Tonya Davis,District-Public,2024-04-01,500023
-Newton County Schools,GA,Tonya Davis,District-Public,2024-03-01,1303930
-Newton Municipal,MS,Tonya Davis,District-Public,2024-05-01,2803180
-Nicollet Public 507,MN,Andy Teipen,District-Public,2024-03-01,2723580
-Niles Community Schools,MI,Andy Teipen,District-Public,2024-07-01,2625560
-North Iowa Community Schools,IA,Andy Teipen,District-Public,2024-04-01,1905750
-Northwest Public Schools,NE,Andy Teipen,District-Public,2024-05-01,3174580
-Northwood 129,ND,Carrie Morrison,District-Public,2024-04-01,3814340
-Norwin School District,PA,Andy Teipen,District-Public,2024-03-01,4217940
-Norwood-Norfolk Central School District,NY,Caison Bridger,District-Public,2024-03-01,3621360
-Notre Dame Preparatory and Marist Academy,MI,Andy Teipen,District-Private,2024-03-01,A1902476
-Nye County School District,NV,Carrie Morrison,District-Public,2024-03-01,3200360
-Oak Hall School,FL,Tonya Davis,District-Private,2024-05-01,A2101215
-Oak Ridge City School District,TN,Caison Bridger,District-Public,2024-05-01,4703240
-Omak School District,WA,Carrie Morrison,District-Public,2024-05-01,5306220
-Oneida Nation School System,WI,Andy Teipen,District-Public,2024-06-01,5900114
-Orange County Public Schools,FL,Caison Bridger,District-Public,2024-04-01,1201440
-Orange Unified School District,CA,Nikki Navta,District-Public,2024-09-01,628650
-Orchard Park Central School District,NY,Caison Bridger,District-Public,2024-04-01,3621900
-Osage Community School,IA,Andy Teipen,District-Public,2024-03-01,1921840
-Overton County,TN,Caison Bridger,District-Public,2024-05-01,4703330
-Pacific Charter Institute,CA,Nikki Navta,District-Charter,2024-03-01,60258214639
-Paradise Valley Unified School District,AZ,Carrie Morrison,District-Public,2024-03-01,405930
-Perrysburg Exempted Village School District,OH,Andy Teipen,District-Public,2024-04-01,3904558
-Pewaukee School District,WI,Andy Teipen,District-Public,2024-05-01,5511640
-Philadelphia Academy Charter School,PA,Andy Teipen,District-Charter,2024-03-01,4218990
-Phoenix Hebrew Academy,AZ,Carrie Morrison,District-Religious,2024-05-01,A2100201
-Pickerington Local School District,OH,Andy Teipen,District-Public,2024-04-01,3904689
-Piedmont Unified School District,CA,Nikki Navta,District-Public,2024-03-01,630330
-Pierce Public Schools,NE,Andy Teipen,District-Public,2024-04-01,3175510
-Plainfield Community School Corporation,IN,Andy Teipen,District-Public,2024-03-01,1808970
-Plato R-V School District,MO,Andy Teipen,District-Public,2024-05-01,2925210
-Plymouth Public Schools,MA,Caison Bridger,District-Public,2024-05-01,2509720
-Pocatello Chubbuck School District #25,ID,Carrie Morrison,District-Public,2024-03-01,1602640
-Portsmouth School District,NH,Caison Bridger,District-Public,2024-03-01,3305820
-Public Schools of the Tarrytowns,NY,Caison Bridger,District-Public,2024-03-01,3628650
-Pueblo School District 60,CO,Carrie Morrison,District-Public,2024-03-01,806120
-Putnam County R-I School District,MO,Andy Teipen,District-Public,2024-04-01,2925640
-Quitman Consolidated School District,MS,Tonya Davis,District-Public,2024-05-01,2803780
-Raleigh County Schools,WV,Andy Teipen,District-Public,2024-03-01,5401230
-Renton School District,WA,Carrie Morrison,District-Public,2024-05-01,5307230
-Richland 44,ND,Carrie Morrison,District-Public,2024-09-01,3800036
-Rio Rancho Public Schools,NM,Carrie Morrison,District-Public,2024-06-01,3500010
-Riverside Unified School District,CA,Nikki Navta,District-Public,2024-05-01,633150
-Riverton Community Unit School District 14,IL,Andy Teipen,District-Public,2024-06-01,1734100
-Roane County School District,WV,Caison Bridger,District-Public,2024-05-01,5401320
-Robertson County Schools,KY,Andy Teipen,District-Public,2024-03-01,4703600
-Rockridge Community Unit School District 300,IL,Andy Teipen,District-Public,2024-05-01,1734440
-Rocky Point Union Free School District,NY,Caison Bridger,District-Public,2024-05-01,3624840
-Rumson-Fair Haven Regional High School District,NJ,Caison Bridger,District-Public,2024-04-01,3414400
-Russell Byers Charter School,PA,Andy Teipen,District-Charter,2024-08-01,420009200577
-Sacramento County Office of Education,CA,Nikki Navta,Regional Partner,2024-03-01,691027
-San Bernardino City Unified School District,CA,Nikki Navta,District-Public,2024-06-01,634170
-San Lorenzo Valley Unified School District,CA,Nikki Navta,District-Public,2024-07-01,634740
-Sargent Central Public School,ND,Carrie Morrison,District-Public,2024-05-01,3816430
-Sawyer Public School District,ND,Carrie Morrison,District-Public,2024-03-01,3816470
-Schenectady School District,NY,Caison Bridger,District-Public,2024-05-01,3626010
-School District of Brown Deer,WI,Andy Teipen,District-Public,2024-05-01,5501800
-School District of Springfield Township,PA,Andy Teipen,District-Public,2024-03-01,4222620
-Scottsdale Unified School District,AZ,Carrie Morrison,District-Public,2024-05-01,407570
-Scribner Snyder Community Schools,NE,Andy Teipen,District-Public,2024-05-01,3100076
-Sevier County School System,TN,Caison Bridger,District-Public,2024-06-01,4703780
-Seymour Community Schools,WI,Andy Teipen,District-Public,2024-05-01,5513530
-Shasta Union High School District,CA,Nikki Navta,District-Public,2024-03-01,636600
-Sheridan County School District #2,WY,Carrie Morrison,District-Public,2024-05-01,5605695
-Shonto Preparatory School,AZ,Carrie Morrison,District-Public,2024-05-01,590012800186
-Sioux City Community School District,IA,Andy Teipen,District-Public,2024-03-01,1926400
-Sitka School District,AK,Carrie Morrison,District-Public,2024-04-01,200240
-Smithfield Public Schools,RI,Caison Bridger,District-Public,2024-03-01,4400990
-Somerville Public Schools,MA,Caison Bridger,District-Public,2024-03-01,3415090
-South Brunswick Township School District,NJ,Caison Bridger,District-Public,2024-04-01,3415210
-South Glens Falls CSD,NY,Caison Bridger,District-Public,2024-04-01,3627240
-South Vermillion Community School Corporation,IN,Andy Teipen,District-Public,2024-03-01,1810590
-Southeastern Massachusetts Educational Collaborative,MA,Caison Bridger,Service Center,2024-07-01,2500560
-Southside Independent School District,TX,Tonya Davis,District-Public,2024-03-01,4840920
-Southwest Parke Community Schools,IN,Andy Teipen,District-Public,2024-03-01,1810900
-Springfield International Charter School,MA,Caison Bridger,District-Public,2024-05-01,250002800537
-Springfield Local Schools,OH,Andy Teipen,District-Public,2024-08-01,3904822
-St Joseph High School,NJ,Caison Bridger,District-Religious,2024-03-01,867902
-St. Johns County School District,FL,Tonya Davis,District-Public,2024-05-01,1201740
-St. Joseph School,IL,Andy Teipen,District-Religious,2024-08-01,345985
-St. Louis County Schools ISD 2142,MN,Andy Teipen,District-Public,2024-05-01,2700008
-Stanislaus County Office of Education,CA,Nikki Navta,District-Public,2024-03-01,637950
-Sudbury Public Schools,MA,Caison Bridger,District-Public,2024-05-01,2511340
-Suffolk Public Schools,VA,Caison Bridger,District-Public,2024-06-01,5103710
-Sweetwater County School District 1,WY,Carrie Morrison,District-Public,2024-04-01,5605302
-Sylvan Lucas Unified School District 299,KS,Andy Teipen,District-Public,2024-05-01,2012120
-Telluride School District No. R-1,CO,Carrie Morrison,District-Public,2024-08-01,806870
-Telra Institute,NC,Caison Bridger,District-Private,2024-03-01,3700472
-The Innovation School,ND,Carrie Morrison,District-Private,2024-04-01,380040500911
-The Lower Alloways Creek School District,NJ,Caison Bridger,District-Public,2024-05-01,3409030
-"Thief River Falls Public Schools, District 564",MN,Andy Teipen,District-Public,2024-05-01,2738850
-Thompson Public Schools,ND,Carrie Morrison,District-Public,2024-03-01,3818280
-Three Rivers Community Schools,MI,Andy Teipen,District-Public,2024-06-01,2633840
-Trinity Christian School,IN,Andy Teipen,District-Religious,2024-08-01,A1301410
-Trinity County Office of Education,CA,Nikki Navta,District-Public,2024-03-01,691044
-Troy School District,MI,Andy Teipen,District-Public,2024-05-01,2634260
-Tulsa Public Schools,OK,Carrie Morrison,District-Public,2024-08-01,4030240
-Twiggs County School District,GA,Tonya Davis,District-Public,2024-03-01,1305220
-Union Area School District,PA,Andy Teipen,District-Public,2024-08-01,4224060
-Uniondale School District,NY,Caison Bridger,District-Public,2024-08-01,3629280
-United #7,ND,Carrie Morrison,District-Public,2024-03-01,3818730
-University City,MO,Andy Teipen,District-Public,2024-03-01,2930660
-Upper Township School District,NJ,Caison Bridger,District-Public,2024-05-01,3416650
-Utica Community Schools,MI,Andy Teipen,District-Public,2024-04-01,2634470
-Voz Collegiate Preparatory Charter School,NM,Carrie Morrison,District-Charter,2024-05-01,350006001164
-Wakefield Community Schools,NE,Andy Teipen,District-Public,2024-03-01,3178240
-Wallingford School District,CT,Caison Bridger,District-Public,2024-04-01,904740
-Warren County Schools,NC,Caison Bridger,District-Public,2024-03-01,4704350
-Washburn Public School,ND,Carrie Morrison,District-Public,2024-04-01,3819290
-Washington County Public Schools,MD,Caison Bridger,District-Public,2024-07-01,2400660
-"Washington Township Schools, Morris County",NJ,Caison Bridger,District-Public,2024-03-01,3417130
-Wayne-Westland Community Schools,MI,Andy Teipen,District-Public,2024-03-01,2600015
-Wentzville School District,MO,Andy Teipen,District-Public,2024-06-01,2931650
-Westhope 17 School District,ND,Carrie Morrison,District-Public,2024-04-01,3819470
-Westlake Academy,TX,Tonya Davis,District-Charter,2024-05-01,4800254
-Whiteriver Unified School District,AZ,Carrie Morrison,District-Public,2024-04-01,409160
-Wichita Public Schools - USD 259,KS,Andy Teipen,District-Public,2024-03-01,2012990
-Williston Basin School District 7,ND,Carrie Morrison,District-Public,2024-06-01,3800405
-Williston Trinity Christian School,ND,Carrie Morrison,District-Religious,2024-06-01,A9303500
-Wilson County Schools,NC,Caison Bridger,District-Public,2024-03-01,4704550
-Woodbine Community School District,IA,Andy Teipen,District-Public,2024-03-01,1931920
-Worcester County Public Schools,MD,Caison Bridger,District-Public,2024-08-01,2400720
-Yukon Flats School District,AK,Carrie Morrison,District-Public,2024-03-01,200775
+district_id,month_closed
+345985,2024-08-01
+867902,2024-03-01
+100390,2024-08-01
+100540,2024-09-01
+101050,2024-09-01
+101290,2024-04-01
+102430,2024-03-01
+1647828,2024-08-01
+1924575,2024-06-01
+200130,2024-05-01
+200240,2024-04-01
+200330,2024-03-01
+200390,2024-03-01
+200510,2024-04-01
+200775,2024-03-01
+40083103196,2024-08-01
+401050,2024-04-01
+405930,2024-03-01
+407570,2024-05-01
+407750,2024-03-01
+409160,2024-04-01
+409250,2024-07-01
+470980,2024-05-01
+500023,2024-04-01
+502700,2024-05-01
+502820,2024-11-01
+503270,2024-04-01
+503710,2024-05-01
+508610,2024-04-01
+601770,2024-08-01
+602160,2024-05-01
+605580,2024-03-01
+609030,2024-03-01
+609480,2024-09-01
+609850,2024-07-01
+614070,2024-03-01
+614880,2024-03-01
+620130,2024-06-01
+622710,2024-06-01
+622830,2024-04-01
+625470,2024-05-01
+625530,2024-05-01
+625800,2024-09-01
+628650,2024-09-01
+630330,2024-03-01
+632130,2023-12-01
+633150,2024-05-01
+634170,2024-06-01
+634740,2024-07-01
+636600,2024-03-01
+637950,2024-03-01
+638010,2024-07-01
+691027,2024-02-01
+691044,2024-03-01
+803360,2024-03-01
+806030,2024-07-01
+806120,2024-03-01
+806870,2024-08-01
+900210,2024-04-01
+900270,2024-04-01
+901920,2024-01-01
+902670,2024-03-01
+902700,2024-06-01
+903090,2024-08-01
+903537,2024-04-01
+904320,2023-11-01
+904740,2024-04-01
+925092,2024-08-01
+1001240,2024-03-01
+1011157,2024-09-01
+1100030,2024-10-01
+1200180,2024-07-01
+1200390,2024-03-01
+1200480,2024-04-01
+1200810,2024-10-01
+1201200,2024-08-01
+1201230,2024-06-01
+1201440,2024-04-01
+1201500,2024-02-01
+1201620,2024-03-01
+1201740,2024-05-01
+1201920,2024-03-01
+1300232,2024-08-01
+1301260,2024-03-01
+1301680,2024-04-01
+1301710,2024-03-01
+1301830,2024-06-01
+1301980,2024-04-01
+130228004259,2024-04-01
+1303000,2024-03-01
+1303930,2024-03-01
+1304530,2024-03-01
+1305220,2024-03-01
+1305859,2024-09-01
+1323654,2024-07-01
+1500030,2024-03-01
+1600060,2024-05-01
+1600300,2024-05-01
+1600510,2024-05-01
+1601860,2024-05-01
+1602640,2024-03-01
+1615217,2024-08-01
+1708430,2024-03-01
+1713560,2024-03-01
+1714460,2024-06-01
+1717520,2024-03-01
+1718840,2024-05-01
+1734100,2024-06-01
+1734440,2024-05-01
+1736300,2024-10-01
+1800042,2024-03-01
+1800067,2024-04-01
+1800630,2024-03-01
+1801440,2024-03-01
+1802550,2024-07-01
+1803630,2024-06-01
+1803750,2024-03-01
+1804170,2024-04-01
+1804350,2024-03-01
+1805190,2024-03-01
+1805700,2024-02-01
+1805880,2024-08-01
+1805910,2024-08-01
+1807020,2024-04-01
+1807290,2024-04-01
+1808970,2024-03-01
+1810590,2023-11-01
+1810900,2024-03-01
+1905750,2024-04-01
+1906540,2024-03-01
+1908910,2024-03-01
+1909480,2024-02-01
+1912480,2024-05-01
+1914700,2024-05-01
+1919140,2024-02-01
+1921840,2024-02-01
+1926400,2024-03-01
+1926790,2024-10-01
+1931920,2024-03-01
+2009420,2024-08-01
+2012000,2024-05-01
+2012120,2024-05-01
+2012990,2023-12-01
+2101470,2023-11-01
+2102990,2024-04-01
+2103750,2024-05-01
+2105040,2024-01-01
+2200090,2024-01-01
+220024702354,2024-10-01
+2200270,2024-04-01
+2200540,2024-10-01
+2201530,2024-06-01
+2280105,2024-04-01
+2306160,2024-05-01
+2400090,2024-06-01
+2400270,2024-07-01
+2400360,2024-07-01
+2400480,2024-07-01
+2400660,2024-07-01
+2400720,2024-08-01
+250002800537,2024-05-01
+2500560,2024-07-01
+2502580,2024-05-01
+2502820,2024-05-01
+2504410,2024-05-01
+2505400,2024-05-01
+2506480,2024-06-01
+2507500,2024-05-01
+2507620,2024-05-01
+2508340,2024-06-01
+2509720,2024-05-01
+2511340,2024-05-01
+2600006,2024-07-01
+2600015,2024-02-01
+2601103,2024-01-01
+2604470,2024-05-01
+2609570,2023-11-01
+2609900,2024-08-01
+2616440,2024-07-01
+2618930,2024-05-01
+2620070,2024-05-01
+2621150,2024-05-01
+2623610,2024-07-01
+2624840,2024-07-01
+2625560,2024-07-01
+2632220,2024-05-01
+2632670,2024-02-01
+2633840,2024-06-01
+2634260,2024-05-01
+2634470,2024-04-01
+2635460,2024-05-01
+2636060,2024-06-01
+2700001,2024-05-01
+2700008,2024-05-01
+2702730,2024-07-01
+2704050,2024-05-01
+2705790,2024-09-01
+2706240,2024-02-01
+2716980,2024-02-01
+2718780,2024-02-01
+2718960,2024-03-01
+2723580,2024-01-01
+2730030,2024-05-01
+2733810,2024-06-01
+2738850,2024-05-01
+2800187,2024-04-01
+2800195,2024-08-01
+2800197,2023-12-01
+2801140,2024-04-01
+2802400,2024-04-01
+2802700,2024-05-01
+2803180,2024-05-01
+2803510,2024-04-01
+2803780,2024-05-01
+2804650,2024-04-01
+2804802,2024-04-01
+2909900,2024-04-01
+2911550,2024-04-01
+2912010,2024-04-01
+2913320,2024-05-01
+2915510,2024-04-01
+2920410,2024-04-01
+2921000,2024-07-01
+2925210,2024-05-01
+2925640,2024-04-01
+2928920,2024-10-01
+2930660,2024-03-01
+2931650,2024-06-01
+3100076,2024-05-01
+3103540,2024-05-01
+3104950,2024-03-01
+3105460,2024-04-01
+3171220,2024-07-01
+3171580,2024-04-01
+3171610,2024-07-01
+3171820,2024-05-01
+3172840,2024-06-01
+3173440,2024-07-01
+3174580,2024-05-01
+3175510,2024-04-01
+3178240,2024-03-01
+320000100800,2024-08-01
+3200060,2023-11-01
+3200120,2024-01-01
+3200210,2024-02-01
+3200270,2024-02-01
+3200300,2023-12-01
+3200360,2023-11-01
+3302610,2024-04-01
+3302990,2023-12-01
+3305310,2024-06-01
+3305820,2024-02-01
+3307360,2024-04-01
+3400070,2024-05-01
+3400078,2024-09-01
+3401260,2024-05-01
+3401290,2024-05-01
+3401830,2024-03-01
+3402730,2024-05-01
+3403360,2024-05-01
+3404020,2024-05-01
+3404170,2024-05-01
+3404380,2024-05-01
+3405970,2024-05-01
+3406330,2024-05-01
+3406540,2024-05-01
+3406660,2024-05-01
+3407230,2024-05-01
+3407950,2024-05-01
+3408040,2024-05-01
+3408430,2024-05-01
+3408520,2024-05-01
+3409000,2024-06-01
+3409030,2024-05-01
+3410080,2024-04-01
+3410140,2024-05-01
+3410200,2024-04-01
+3410380,2024-08-01
+3410560,2024-05-01
+3411220,2024-07-01
+3411340,2024-01-01
+3411610,2024-05-01
+3411970,2024-05-01
+3413140,2024-04-01
+3414400,2024-04-01
+3415090,2023-12-01
+3415210,2024-04-01
+3415630,2024-05-01
+3416470,2024-05-01
+3416650,2024-05-01
+3416710,2024-05-01
+3417130,2024-02-01
+3418120,2024-04-01
+3500010,2024-06-01
+350006001164,2024-05-01
+3500660,2024-05-01
+3500930,2024-04-01
+3501500,2024-04-01
+3600088,2024-05-01
+360013705766,2024-05-01
+3600153,2024-05-01
+3601030,2024-04-01
+360113606549,2024-04-01
+3603270,2024-05-01
+3611740,2024-05-01
+3612630,2024-07-01
+3614430,2024-01-01
+3616560,2024-01-01
+3619380,2024-06-01
+3620490,2024-04-01
+3621360,2024-01-01
+3621900,2024-04-01
+3624150,2023-11-01
+3624840,2024-05-01
+3626010,2024-05-01
+3627240,2024-04-01
+3627810,2024-05-01
+3628650,2024-03-01
+3629280,2024-08-01
+3630660,2023-11-01
+3630930,2024-04-01
+3680820,2024-05-01
+3700011,2024-06-01
+3700086,2024-05-01
+3700089,2024-07-01
+3700108,2024-05-01
+3700121,2024-03-01
+3700472,2023-12-01
+3700477,2024-06-01
+3700630,2024-08-01
+3700780,2024-08-01
+3700960,2024-02-01
+3701080,2023-12-01
+3701170,2024-05-01
+3701200,2024-06-01
+3701620,2024-05-01
+3701920,2024-03-01
+3702040,2024-09-01
+3702250,2024-07-01
+3702370,2024-04-01
+3702880,2024-04-01
+3704740,2024-03-01
+3800018,2024-03-01
+3800025,2024-06-01
+3800027,2024-06-01
+3800031,2024-04-01
+3800036,2024-09-01
+3800040,2024-04-01
+3800041,2024-03-01
+3800046,2024-04-01
+3800059,2024-10-01
+3800405,2024-06-01
+380040500911,2024-04-01
+3801760,2024-06-01
+3806910,2024-03-01
+3807590,2024-06-01
+3809570,2024-03-01
+3810180,2024-04-01
+3812920,2024-05-01
+3813400,2024-04-01
+3813510,2024-04-01
+3814340,2024-04-01
+3814940,2024-10-01
+3816430,2024-05-01
+3816470,2024-03-01
+3817570,2024-06-01
+3818280,2024-03-01
+3818730,2024-03-01
+3819290,2024-04-01
+3819470,2024-04-01
+390004002939,2023-11-01
+3900567,2024-09-01
+3904378,2024-01-01
+3904380,2024-05-01
+3904395,2024-06-01
+3904543,2024-04-01
+3904558,2024-04-01
+3904613,2024-04-01
+3904676,2024-07-01
+3904689,2024-04-01
+3904813,2024-03-01
+3904822,2024-08-01
+3905002,2024-04-01
+400077702789,2024-04-01
+4002760,2024-07-01
+40042703160,2024-05-01
+4007670,2024-09-01
+4008310,2024-07-01
+4008850,2024-08-01
+4016530,2024-08-01
+4030240,2024-08-01
+4032010,2024-07-01
+420009200577,2024-08-01
+4200138,2024-08-01
+4203480,2024-06-01
+4212170,2024-10-01
+4217940,2024-01-01
+4218990,2024-01-01
+4222620,2023-11-01
+4224060,2024-08-01
+4289310,2024-01-01
+4400990,2024-02-01
+4500720,2024-08-01
+4501110,2024-08-01
+4501250,2024-08-01
+4501440,2024-05-01
+4501770,2024-05-01
+4501860,2024-05-01
+4502700,2024-07-01
+4502730,2024-04-01
+4700090,2024-06-01
+4700142,2024-02-01
+4700148,2024-01-01
+4700151,2024-04-01
+4700330,2024-05-01
+4700360,2024-05-01
+4700750,2024-05-01
+4701080,2024-05-01
+4701860,2024-04-01
+4702130,2024-05-01
+4702490,2024-06-01
+4702790,2024-05-01
+4703180,2024-08-01
+4703240,2024-05-01
+4703330,2024-05-01
+4703780,2024-06-01
+4704550,2024-02-01
+4800008,2024-04-01
+4800011,2024-05-01
+4800254,2024-06-01
+4800292,2023-12-01
+4801431,2024-08-01
+4812780,2024-05-01
+4814400,2024-05-01
+4815180,2024-05-01
+4815240,2024-04-01
+4815910,2024-06-01
+4817700,2024-09-01
+4818000,2024-06-01
+4822140,2024-10-01
+4822170,2024-05-01
+4822770,2024-05-01
+4823910,2024-02-01
+4824530,2024-04-01
+4827330,2024-05-01
+4827870,2024-09-01
+4829820,2024-05-01
+4830360,2024-02-01
+4830930,2024-05-01
+4835730,2024-05-01
+4839360,2024-08-01
+4840920,2024-02-01
+4841280,2024-07-01
+4841350,2024-08-01
+4842570,2024-06-01
+4899130,2024-06-01
+5100152,2024-06-01
+5101470,2024-05-01
+5102250,2024-05-01
+5102360,2024-05-01
+5103420,2024-05-01
+5103710,2024-06-01
+5300347,2024-05-01
+5301410,2024-05-01
+5304230,2024-04-01
+5304860,2024-06-01
+5306220,2024-05-01
+5307230,2024-05-01
+5400210,2024-09-01
+5400300,2024-01-01
+5401230,2024-01-01
+5401320,2024-05-01
+5501770,2024-05-01
+5501800,2024-05-01
+5502880,2024-04-01
+5503060,2024-06-01
+5503690,2024-05-01
+5505220,2024-07-01
+5508790,2024-05-01
+5511640,2024-05-01
+5512330,2024-10-01
+5513530,2024-05-01
+5513650,2023-11-01
+5602150,2024-04-01
+5605302,2024-04-01
+5605695,2024-05-01
+5700000,2024-04-01
+5900114,2024-06-01
+590012800186,2024-05-01
+60258214639,2024-02-01
+8000000,2024-04-01
+A1192099,2024-07-01
+A1301410,2024-08-01
+A1701777,2024-04-01
+A1701794,2024-01-01
+A1902476,2024-02-01
+A1992045,2024-07-01
+A2100201,2024-05-01
+A2101215,2024-05-01
+A2102807,2023-11-01
+A9104446,2024-05-01
+A9303500,2024-06-01

--- a/dbt/models/marts/districts/_districts__models.yml
+++ b/dbt/models/marts/districts/_districts__models.yml
@@ -64,7 +64,7 @@ models:
       **inactive churn**: was "inactive" last school year and so far this school year    
       **market**: has never had a school considered "active" on code.org      
 
-      This model also contains information about those **enrolled** in our district program, and the particular school year in which they enrolled. If you see a single district with "enrolled this year" = 1 for multiple school years, this represents a suplicate in the source data, and warrants a fix in data collection. 
+      This model also contains information about those **enrolled** in our district program **as of 11/8/24**, and the particular school year in which they enrolled. If you see a single district with "enrolled this year" = 1 for multiple school years, this represents a suplicate in the source data, and warrants a fix in data collection. 
    
     columns:
       - name: school_district_id

--- a/dbt/models/marts/districts/_districts__models.yml
+++ b/dbt/models/marts/districts/_districts__models.yml
@@ -64,7 +64,7 @@ models:
       **inactive churn**: was "inactive" last school year and so far this school year    
       **market**: has never had a school considered "active" on code.org      
 
-      This model also contains information about those **enrolled** in our district program **as of 11/8/24**, and the particular school year in which they enrolled. If you see a single district with "enrolled this year" = 1 for multiple school years, this represents a suplicate in the source data, and warrants a fix in data collection. 
+      This model also contains information about those **enrolled** in our district program **as of 11/8/24**, and the particular school year and month in which they enrolled. If you see a single district with "enrolled this year" = 1 for multiple school years, this represents a duplicate in the source data, and warrants a fix in data collection. 
    
     columns:
       - name: school_district_id
@@ -87,5 +87,7 @@ models:
         description: 1 if the district is enrolled in our district program (enrolled this school year or any year prior), 0 otherwise
       - name: is_target_this_year
         description: 1 if the district is a target district program this year, else 0
+      - name: enrolled_at
+        description: month of enrollment in the district program
     config:
       tags: ['released']

--- a/dbt/models/marts/districts/dim_district_status.sql
+++ b/dbt/models/marts/districts/dim_district_status.sql
@@ -191,6 +191,10 @@ final as (
             when dt.school_year is not null then 1
             else 0
         end                                                             as is_target_this_year
+        , case
+            when de_2.school_year_enrolled is not null then de_2.month_closed
+            else null 
+        end                                                             as enrolled_at
     from full_status                                                    as fs
     left join districts_enrolled                                        as de_1
         on fs.school_district_id = de_1.district_id 

--- a/dbt/models/staging/external_datasets/stg_external_datasets__districts_enrolled.sql
+++ b/dbt/models/staging/external_datasets/stg_external_datasets__districts_enrolled.sql
@@ -11,7 +11,8 @@ school_years as (
 )
 
 select 
-    de.*
+    de.district_id
+    , de.month_closed 
     , sy.school_year                                                as school_year_enrolled 
 from districts_enrolled                                             as de
 join school_years                                                   as sy


### PR DESCRIPTION
# Description

This PR:
1. updates the enrolled districts seed file to include the newly enrolled districts
2. adds enrolled_at to dim_district_status for the school year of enrollment
3. updates documentation to include the date the seed file was last updated

## Links

Jira ticket(s): [DATAOPS-1050](https://codedotorg.atlassian.net/jira/software/projects/DATAOPS/boards/72/backlog?assignee=631ee7e61f3f6665a603964a&selectedIssue=DATAOPS-1050)
