### PR TITLE
add fields requested by global team

### DIFF
--- a/dbt/models/marts/students/dim_student_script_level_activity.sql
+++ b/dbt/models/marts/students/dim_student_script_level_activity.sql
@@ -231,7 +231,6 @@ final as (
 
         -- activity dates
         sta.activity_date,
-        sta.activity_month,
         sta.activity_quarter, 
         
         -- curriculum content of the activity 

--- a/dbt/models/marts/students/dim_student_script_level_activity.sql
+++ b/dbt/models/marts/students/dim_student_script_level_activity.sql
@@ -38,7 +38,8 @@ course_structure as (
         level_type,
         unit        as unit_name,
         stage_id    as lesson_id,
-        stage_name  as lesson_name
+        stage_name  as lesson_name,
+        published_state
     from {{ ref('dim_course_structure') }}
     
     where participant_audience = 'student' 
@@ -78,6 +79,7 @@ student_activity as (
         cs.unit_name,
         cs.lesson_id,
         cs.lesson_name,
+        cs.published_state,
 
         -- aggs
         ul.total_attempts,
@@ -149,6 +151,7 @@ schools as (
 users as (
     select 
         user_id, 
+        us_intl,
         is_international, 
         country,
         user_type
@@ -241,6 +244,7 @@ final as (
         sta.level_id,
         sta.level_name,
         sta.level_type,
+        sta.published_state,
 
         -- activity metrics
         sta.total_attempts,
@@ -248,6 +252,7 @@ final as (
         sta.time_spent_minutes,
 
         -- User characteristics
+        usr.us_intl,
         usr.is_international,
         usr.country,
         usr.user_type,

--- a/dbt/models/marts/students/dim_student_script_level_activity.sql
+++ b/dbt/models/marts/students/dim_student_script_level_activity.sql
@@ -231,6 +231,7 @@ final as (
 
         -- activity dates
         sta.activity_date,
+        sta.activity_month,
         sta.activity_quarter, 
         
         -- curriculum content of the activity 


### PR DESCRIPTION
This PR adds published_state and us_intl fields to the dim_ssla model, since the global team commonly needs to access/ filter by these fields. There could be an argument to keep published_state in course_structure since that join should be made easier by the level_script_id field being added to both models. Feedback on this welcomed!

Jira ticket(s): [DATAOPS-1079](https://codedotorg.atlassian.net/jira/software/projects/DATAOPS/boards/72/backlog?selectedIssue=DATAOPS-1079)