### PR TITLE
Feature/user levels upstream update content fields

### DIFF
--- a/dbt/models/marts/students/dim_student_script_level_activity.sql
+++ b/dbt/models/marts/students/dim_student_script_level_activity.sql
@@ -4,6 +4,8 @@
 -- version: 3.0 (Natalia)
 -- 2024-10-01 
 -- Made changes to include all users with activity in student-facing content
+-- 2024-11-27 
+-- Made changes to include fields content_area and topic_tags to classify curriculum (source:dim_user_levels)
 
 with 
 /*
@@ -24,10 +26,12 @@ user_levels as (
         created_date                        as activity_date,
         extract('month' from created_date)  as activity_month
     from {{ ref('dim_user_levels') }}
+
 ), 
 
 course_structure as (
-    select
+    select distinct
+        content_area,
         course_name,
         course_id,
         script_id,
@@ -39,12 +43,14 @@ course_structure as (
         unit        as unit_name,
         stage_id    as lesson_id,
         stage_name  as lesson_name,
+        topic_tags,
         published_state
-    from {{ ref('dim_course_structure') }}
+    from {{ ref('dim_course_structure')}}
+    where 
+    content_area ilike 'curriculum%'    -- student-facing curriculum
+    or content_area in ('hoc')          -- HOC activities 
     
-    where participant_audience = 'student' 
-    -- Note: filter out data we don't want or need as early as possible. If we keep it around, it will be continuously processed as it is referenced in other queries.
-),
+ ),
 
 school_years as (
     select * 
@@ -72,6 +78,7 @@ student_activity as (
             when ul.activity_month in ( 4,   5,  6 )  then 'Q4'
         end as activity_quarter, 
 
+        cs.content_area,
         cs.course_name,
         cs.level_name,
         cs.level_type,
@@ -80,6 +87,7 @@ student_activity as (
         cs.lesson_id,
         cs.lesson_name,
         cs.published_state,
+        cs.topic_tags,
 
         -- aggs
         ul.total_attempts,
@@ -88,7 +96,7 @@ student_activity as (
 
     from user_levels as ul 
     
-    left join course_structure as cs
+    join course_structure as cs  -- Changed to join to keep only student-facing content
         on ul.level_script_id = cs.level_script_id
 
     join school_years as sy
@@ -139,8 +147,8 @@ sections as (
     3. Teachers and Schools
         a. Use student_id to connect to sections
         b. Use teacher, school_id for statuses
-        c. select * that shit
-        d. almost forgot user_geo info 
+        c. select *
+        d. user_geo info 
 */
 
 schools as (
@@ -235,6 +243,7 @@ final as (
         sta.activity_quarter, 
         
         -- curriculum content of the activity 
+        sta.content_area,
         sta.course_name,
         sta.unit_name,
         sta.script_id,
@@ -245,6 +254,7 @@ final as (
         sta.level_name,
         sta.level_type,
         sta.published_state,
+        sta.topic_tags,
 
         -- activity metrics
         sta.total_attempts,

--- a/dbt/models/marts/students/dim_student_script_level_activity.sql
+++ b/dbt/models/marts/students/dim_student_script_level_activity.sql
@@ -47,7 +47,7 @@ course_structure as (
         published_state
     from {{ ref('dim_course_structure')}}
     where 
-    content_area ilike 'curriculum%'    -- student-facing curriculum
+    content_area like 'curriculum%'    -- student-facing curriculum
     or content_area in ('hoc')          -- HOC activities 
     
  ),

--- a/dbt/models/marts/teachers/dim_self_paced_pd_activity.sql
+++ b/dbt/models/marts/teachers/dim_self_paced_pd_activity.sql
@@ -10,7 +10,7 @@ course_structure as (
         and instruction_type = 'self_paced'
         )
         and script_name not in ('alltheselfpacedplthings')
-        and course_name not like 'pd workshop activity%'
+        and content_area like '%self_paced_pl%'
 ),
 
 user_levels as (
@@ -52,6 +52,8 @@ self_paced_scripts as (
         , cs.level_number
         , cs.level_script_order
         , cs.course_name
+        , cs.content_area
+        , cs.topic_tags
         , case 
             when cs.script_name ilike 'k5-onlinepd%' 		    then 'csf'
 			when cs.script_name like 'self-paced-pl-k5%'	    then 'csf'
@@ -83,6 +85,8 @@ select distinct
     , sps.stage_name
     , sps.level_name
     , sps.course_name
+    , sps.content_area
+    , sps.topic_tags
     , sps.course_name_implementation
     , ul.created_date                                                                   as level_created_dt
     , sy.school_year                                                                    as level_created_school_year


### PR DESCRIPTION
## This PR has changes to two models adding the new fields content_area and topic_tags:

**1. `dim_student_script_level_activity`**
Changes:
a. Include content_area and topic_tags
b. Filtered the CTE for dim_course_structure to only pull student-facing content:  content_area like 'curriculum%' or content_area in ('hoc')
c. Change the left join from user_levels to course_structure to an inner join to actually limit the content of the model to student-facing one. This was also causing a significant number of records with nulls in the fields labeling the curriculum (course_name, script_name, etc.).

**2. `dim_self_paced_pd_activity`**
Changes:
a. Include content_area and topic_tags


### Validation 
The following code was used to validate that the changes worked and there were no changes to upstream models

**1. `dim_student_script_level_activity`**

a. No impact on `dim_user_course_activity`: difference in student counts by course and school year between prod and test schema is -1 for a CSF student in 2022-23.
```
with 
test as (
select 
 school_year
, course_name
, user_type
, count(distinct user_id) n_users
from 
dev.dbt_natalia.dim_user_course_activity
group by 1,2,3
)
--
, prod as (
select 
 school_year
, course_name
, user_type
, count(distinct user_id) n_users
from 
dev.analytics.dim_user_course_activity
group by 1,2,3
)
--
select  
  p.school_year
, p.course_name
, p.user_type
, p.n_users
, t.n_users
, (p.n_users - t.n_users) diff_n_users
from prod p
left join test t 
on p.school_year = t.school_year
and p.course_name = t.course_name
and p.user_type = t.user_type
where p.n_users <> t.n_users
order by 1,2,3
;
```

b. No impact on `dim_active_students`: difference in student counts by school year between prod and test schema is null


```
with 
test as (
select 
school_year
, is_active_student
, has_user_level_activity
, count(distinct student_id) n_students
from dev.dbt_natalia.dim_active_students s
group by 1,2,3
)
--
, prod as (
select 
school_year
, is_active_student
, has_user_level_activity
, count(distinct student_id) n_students
from dev.analytics.dim_active_students s
group by 1,2,3
)
--
select 
  p.school_year
, p.is_active_student
, p.has_user_level_activity
, p.n_students
, t.n_students
from prod p
left join  test t 
on p.school_year = t.school_year
and p.is_active_student = t.is_active_student
and p.has_user_level_activity = t.has_user_level_activity
where p.n_students <> t.n_students
order by 1,2,3
;
```

c. Impact on `dim_student_script_level_activity`: difference in student counts by course and school year between prod and test schema is null
```
with 
test as (
select 
 school_year
, course_name
, user_type
, count(distinct student_id) n_users
from 
dev.dbt_natalia.dim_student_script_level_activity sla 
group by 1,2,3
)
--
, prod as (
select 
 school_year
, course_name
, user_type
, count(distinct student_id) n_users
from 
dev.analytics.dim_student_script_level_activity sla 
group by 1,2,3
)
--
select  
  p.school_year
, p.course_name
, p.user_type
, p.n_users
, t.n_users
, (p.n_users - t.n_users) diff_n_users
from prod p
left join test t 
on p.school_year = t.school_year
and p.course_name = t.course_name
and p.user_type = t.user_type
where p.n_users <> t.n_users
order by 1,2,3
;
```

d. Data including `content_area` and `topic_tags` displays is as expected:
```
select 
school_year
, content_area
, course_name
, script_name
, topic_tags
, count(distinct student_id) n_users
from 
dev.dbt_natalia.dim_student_script_level_activity sla 
where school_year = '2024-25'
group by 1,2,3,4,5
order by 1,2,3,4,5
;
```

e. No data with null course_name:
```
select distinct  
 content_area
, course_name 
, script_name 
from dev.dbt_natalia.dim_course_structure cs
where 
 course_name is null
order by 1;
```

**2. dim_self_paced_pd_activity **

a. difference in course counts between prod and test schema: difference is null
 ```
with 
test as (
select 
level_created_school_year as school_year
, course_name
, count(distinct teacher_id) n_users
from 
dev.dbt_natalia.dim_self_paced_pd_activity
group by 1,2
)
--
, prod as (
select 
 level_created_school_year as school_year
, course_name
, count(distinct teacher_id) n_users
from 
dev.analytics.dim_self_paced_pd_activity
group by 1,2
)
--
select  
  p.school_year
, p.course_name
, p.n_users
, t.n_users
, (p.n_users - t.n_users) diff_n_users
from prod p
left join test t 
on p.school_year = t.school_year
and p.course_name = t.course_name
where p.n_users <> t.n_users
order by 1,2,3
;
```

b. Data including `content_area` and `topic_tags` displays is as expected:
```
select 
course_name
, content_area
, topic_tags
, count(distinct teacher_id) n_users
from 
dev.dbt_natalia.dim_self_paced_pd_activity
where level_created_school_year in ('2023-24', '2024-25')
group by 1,2,3
order by 1,2,3
```

## Links

Jira ticket(s): [DATAOPS-1084](https://codedotorg.atlassian.net/browse/DATAOPS-1084?atlOrigin=eyJpIjoiZTgyNjlhNWZiYTU5NGJiZGI3YzUyNTQ2MjI2MGYyMWQiLCJwIjoiaiJ9)

