### PR TITLE
Feature/ add field num_levels_course_progress to dim user course activity

### DIFF
--- a/dbt/models/marts/users/dim_user_course_activity.sql
+++ b/dbt/models/marts/users/dim_user_course_activity.sql
@@ -52,7 +52,8 @@ course_structure as (
     select  
         course_name, 
         level_id, 
-        script_id 
+        script_id, 
+        level_type
     from {{ ref('dim_course_structure') }}
     where is_active_student_course = 1
 ),
@@ -78,6 +79,18 @@ combined as (
         min(ul.created_at)                      as first_activity_at,
 		max(ul.created_at)                      as last_activity_at,
         count(distinct ul.user_level_id)        as num_levels,
+        count (distinct 
+                case 
+                    when cs.level_type in (
+                        'curriculumreference'
+                        , 'standalonevideo'
+                        , 'freeresponse'
+                        , 'external'
+                        , 'externallink'
+                        , 'map'
+                        , 'levelgroup')
+                        then null 
+                    else ul.user_level_id end )      as num_levels_course_progress, -- levels that count for course progress because they indicate on-platform activity. Used for 6-12 curriculum
         count(distinct trunc(ul.created_at))    as num_unique_days,
         sum(time_spent)                         as sum_time_spent
 

--- a/dbt/models/marts/users/dim_user_course_activity.sql
+++ b/dbt/models/marts/users/dim_user_course_activity.sql
@@ -113,4 +113,3 @@ combined as (
 
 select *
 from combined
-where school_year = '2023-24'

--- a/dbt/models/marts/users/dim_user_course_activity.sql
+++ b/dbt/models/marts/users/dim_user_course_activity.sql
@@ -50,7 +50,9 @@ user_levels as (
 
 course_structure as (
     select  
+        content_area,
         course_name, 
+        topic_tags,
         level_id, 
         script_id, 
         level_type
@@ -75,7 +77,9 @@ combined as (
         sy.school_year,
         u.us_intl,
         u.country,
+        cs.content_area,
         cs.course_name,
+        cs.topic_tags,
         min(ul.created_at)                      as first_activity_at,
 		max(ul.created_at)                      as last_activity_at,
         count(distinct ul.user_level_id)        as num_levels,
@@ -105,7 +109,8 @@ combined as (
             between sy.started_at 
                 and sy.ended_at
                 
-    {{ dbt_utils.group_by(6) }} )
+    {{ dbt_utils.group_by(8) }} )
 
 select *
 from combined
+where school_year = '2023-24'


### PR DESCRIPTION
This PR adds field `num_levels_course_progress` to `dim_user_course_activity` which counts the distinct levels per course where students engage with on-platform content: instead of counting all levels it excludes some content such as videos, external links, free responses, surveys, and assessments, so it allows for better comparisons across sections. 
