### PR TITLE
Feature/dim_pl_workshops

### DIFF
--- a/dbt/models/intermediate/int_active_sections.sql
+++ b/dbt/models/intermediate/int_active_sections.sql
@@ -10,7 +10,7 @@ student_course_starts as (
     select *
     from {{ ref('dim_user_course_activity') }}
     where user_id in (select student_id from student_section)
-    and user_type = 'student'
+    --and user_type = 'student'
 ),
 
 combined as (

--- a/dbt/models/intermediate/int_active_sections.sql
+++ b/dbt/models/intermediate/int_active_sections.sql
@@ -10,6 +10,7 @@ student_course_starts as (
     select *
     from {{ ref('dim_user_course_activity') }}
     where user_id in (select student_id from student_section)
+    and user_type = 'student'
 ),
 
 combined as (

--- a/dbt/models/intermediate/int_pl_workshops.sql
+++ b/dbt/models/intermediate/int_pl_workshops.sql
@@ -1,0 +1,151 @@
+with 
+
+pd_enrollments as (
+    select * 
+    from {{ ref('stg_dashboard_pii__pd_enrollments') }}
+),
+
+pd_attendances as (
+    select * 
+    from {{ ref('stg_dashboard_pii__pd_attendances') }}
+),
+
+pd_sessions as (
+    select * 
+    from {{ ref('stg_dashboard_pii__pd_sessions') }}
+),
+
+course_offerings as ( 
+    select * 
+    from {{ ref('stg_dashboard__course_offerings') }}
+),
+
+course_offerings_pd_workshops as ( 
+    select * 
+    from {{ ref('stg_dashboard_pii__course_offerings_pd_workshops') }}
+),
+
+course_structure as (
+    select *
+        , replace(replace(replace(content_area, 'curriculum_', ''), 'self_paced_pl_', ''), '_self_paced_pl', '') as grade_band
+    from {{ ref('dim_course_structure') }}
+    where content_area != 'other'
+),
+
+course_grade_band as (
+    select distinct
+        course_name,
+        grade_band
+    from course_structure
+),
+
+regional_partners as (
+    select * 
+    from {{ ref('dim_regional_partners') }}
+),
+
+content_area_mapping as (
+    select distinct 
+        wco.course_offering_id,
+        cs.grade_band
+    from course_offerings_pd_workshops wco 
+    join course_offerings co 
+        on wco.course_offering_id = co.course_offering_id 
+    left join course_structure cs on co.key = cs.family_name
+),
+
+enrollments_by_workshop as ( 
+    select 
+        pd_workshop_id,
+        count(distinct teacher_id) as num_teachers_enrolled 
+    from pd_enrollments
+    group by 1
+),
+
+sessions_by_workshop as (
+    select 
+        pd_workshop_id,
+        count(distinct pd_session_id) as num_sessions
+    from pd_sessions
+    group by 1
+),
+
+pd_workshops as (
+    select 
+        pd_workshop_id
+        , organizer_id
+        , school_year
+        , course_name
+        , subject as workshop_subject
+        , started_at as workshop_started_at
+        , regional_partner_id 
+        , is_byow
+    from {{ ref('stg_dashboard_pii__pd_workshops') }}
+),
+
+session_teacher_attendance as (
+    select 
+        pda.teacher_id,
+        pds.pd_workshop_id,
+        count(distinct pda.pd_session_id) as num_sessions_attended
+    from pd_attendances pda 
+    left join pd_sessions pds 
+        on pda.pd_session_id = pds.pd_session_id
+    group by 1,2
+),
+
+attendances_by_workshop as ( 
+    select 
+        pd_workshop_id,
+        count(distinct teacher_id) as num_teachers_attended 
+    from session_teacher_attendance
+    group by 1
+),
+
+avg_sessions_attended as (
+    select 
+        pd_workshop_id,
+        avg(cast(num_sessions_attended as float)) as avg_sessions_attended
+    from session_teacher_attendance
+    group by 1
+)
+
+select 
+    pd_workshops.pd_workshop_id as pl_workshop_id,
+    pd_workshops.organizer_id as pl_organizer_id,
+    pd_workshops.regional_partner_id as pl_regional_partner_id,
+    pd_workshops.school_year,
+    pd_workshops.workshop_subject,
+    pd_workshops.workshop_started_at,
+    is_byow,
+    case 
+        when pd_workshops.course_name = 'build your own workshop' then co.display_name
+        else pd_workshops.course_name
+    end                                             as topic,
+    coalesce(cam.grade_band, cg.grade_band)         as grade_band,
+    cast(e.num_teachers_enrolled as float)          as num_teachers_enrolled,
+    cast(a.num_teachers_attended as float)          as num_teachers_attended,
+    cast(s.num_sessions as float)                   as num_sessions,
+    round(asa.avg_sessions_attended, 3) :: decimal(10,4) as avg_sessions_attended,
+    round(asa.avg_sessions_attended / s.num_sessions, 3) :: decimal(10,4) as pct_sessions_attended
+
+from pd_workshops
+left join enrollments_by_workshop e 
+    on pd_workshops.pd_workshop_id = e.pd_workshop_id
+left join attendances_by_workshop a 
+    on pd_workshops.pd_workshop_id = a.pd_workshop_id
+left join sessions_by_workshop s 
+    on pd_workshops.pd_workshop_id = s.pd_workshop_id
+left join avg_sessions_attended asa 
+    on pd_workshops.pd_workshop_id = asa.pd_workshop_id
+left join course_grade_band cg 
+    on pd_workshops.course_name = cg.course_name
+left join course_offerings_pd_workshops copw 
+    on pd_workshops.pd_workshop_id = copw.pd_workshop_id
+left join content_area_mapping cam 
+    on copw.course_offering_id = cam.course_offering_id
+left join course_offerings co 
+    on copw.course_offering_id = co.course_offering_id
+
+    
+

--- a/dbt/models/marts/professional_development/_professional_development__models.yml
+++ b/dbt/models/marts/professional_development/_professional_development__models.yml
@@ -100,12 +100,14 @@ models:
         description: number of teachers who enrolled in the workshop
       - name: num_teachers_attended 
         description: number of teachers who attended at least 1 session of the workshop 
+      - name: pct_teachers_attended 
+        description: number of teachers who attended at least 1 session / number of enrolled teachers
       - name: num_sessions
         description: the number of sessions offered by the workshop
       - name: avg_sessions_attended
-        description: the average number of sessions attended by teachers who attended any amount of the workshop
+        description: the average number of sessions attended by teachers who attended any amount of the workshop. Those who enrolled but did not attend would not be counted towards this average. 
       - name: pct_sessions_attended
-        description: the percent of all sessions offered that were attended by the workshop teachers
+        description: the percent of all sessions offered that were attended by the workshop teachers. Those who enrolled but did not attend would not be counted towards this percent. 
       - name: topics 
         description: a comma separated list of topics selected by the workshop organizer
       - name: grade_bands

--- a/dbt/models/marts/professional_development/_professional_development__models.yml
+++ b/dbt/models/marts/professional_development/_professional_development__models.yml
@@ -3,7 +3,7 @@ version: 2
 models: 
   - name: dim_pl_activity
     description: |
-      this model has one record for every teacher who starts self-paced or attends facilitated PL for a particular topic (or course) in a given school year. 
+      this model has one record for every teacher who starts self-paced or attends facilitated PL for a particular topic (or course) in a given school year. The grain of the model is teacher_id / pl_type / school_year / workshop_id / topic
     columns: 
       - name: teacher_id
         data_tests:
@@ -73,5 +73,42 @@ models:
         description: 1 if the teacher was an in-classroom teacher either in that same school year as training or the following school year
       - name: sustained
         description: 1 if the teacher was n in-classroom teacher for the year after implementing
+    config:
+      tags: ['released']
+
+  - name: dim_pl_workshops
+    description: |
+        this model has a row for every facilitated PL workshop, and various stats on enrollment and attendance. 
+    columns: 
+      - name: pl_workshop_id
+        data_tests:
+          - not_null
+          - unique
+      - name: pl_organizer_id 
+        description: the user_id associated with the creater of the workshop. 
+      - name: pl_regional_partner_id
+        description: if the organizer is a regional partner, this is the ID associated with the RP. Null otherwise. 
+      - name: school_year
+        description: the school year associated with the workshop start date
+      - name: workshop_subject
+        description: the subject selected for the workshop (e.g. intro, deep dive, district, etc)
+      - name: workshop_started_at 
+        description: the start date selected by the organizer
+      - name: is_byow
+        description: 1 if the workshop is "build your own workshop", 0 otherwise
+      - name: num_teachers_enrolled 
+        description: number of teachers who enrolled in the workshop
+      - name: num_teachers_attended 
+        description: number of teachers who attended at least 1 session of the workshop 
+      - name: num_sessions
+        description: the number of sessions offered by the workshop
+      - name: avg_sessions_attended
+        description: the average number of sessions attended by teachers who attended any amount of the workshop
+      - name: pct_sessions_attended
+        description: the percent of all sessions offered that were attended by the workshop teachers
+      - name: topics 
+        description: a comma separated list of topics selected by the workshop organizer
+      - name: grade_bands
+        description: a comma separated list of the grade bands associated with the topics/ courses selected by the organizer
     config:
       tags: ['released']

--- a/dbt/models/marts/professional_development/_professional_development__models.yml
+++ b/dbt/models/marts/professional_development/_professional_development__models.yml
@@ -93,7 +93,13 @@ models:
       - name: workshop_subject
         description: the subject selected for the workshop (e.g. intro, deep dive, district, etc)
       - name: workshop_started_at 
-        description: the start date selected by the organizer
+        description: the day of the first session of the workshop
+      - name: workshop_ended_at 
+        description: the day of the last session of the workshop
+      - name: participant_group_type 
+        description: added dec 2024, indicates the primary audience of the workshop
+      - name: is virtual
+        description: 1 if the workshop is labeled as virtual, 0 otherwise
       - name: is_byow
         description: 1 if the workshop is "build your own workshop", 0 otherwise
       - name: num_teachers_enrolled 

--- a/dbt/models/marts/professional_development/_professional_development__models.yml
+++ b/dbt/models/marts/professional_development/_professional_development__models.yml
@@ -97,7 +97,7 @@ models:
       - name: workshop_ended_at 
         description: the day of the last session of the workshop
       - name: participant_group_type 
-        description: added dec 2024, indicates the primary audience of the workshop
+        description: added dec 2024, indicates the primary audience of the workshop (e.g. district, multi-district, regional)
       - name: is virtual
         description: 1 if the workshop is labeled as virtual, 0 otherwise
       - name: is_byow

--- a/dbt/models/marts/professional_development/dim_pl_activity.sql
+++ b/dbt/models/marts/professional_development/dim_pl_activity.sql
@@ -91,7 +91,7 @@ left join school_years sy
     on pdw.school_year = sy.school_year
 left join teacher_schools_historical tsh
     on pda.teacher_id = tsh.teacher_id
-    and sy.started_at between tsh.started_at and tsh.ended_at
+    and sy.ended_at between tsh.started_at and tsh.ended_at
 left join teachers 
     on pda.teacher_id = teachers.teacher_id
 left join schools 

--- a/dbt/models/marts/professional_development/dim_pl_activity.sql
+++ b/dbt/models/marts/professional_development/dim_pl_activity.sql
@@ -53,60 +53,52 @@ pd_sessions as (
 
 pd_workshops as (
     select 
-        pd_workshop_id
-        , organizer_id
-        , school_year
-        , course_name
-        , subject as workshop_subject
-        , started_at as workshop_started_at
-        , regional_partner_id 
-        , is_byow
-    from {{ ref('stg_dashboard_pii__pd_workshops') }}
+    from {{ ref('dim_pl_workshops') }}
 ),
 
-course_offerings as ( 
-    select * 
-    from {{ ref('stg_dashboard__course_offerings') }}
-),
+-- course_offerings as ( 
+--     select * 
+--     from {{ ref('stg_dashboard__course_offerings') }}
+-- ),
 
-course_offerings_pd_workshops as ( 
-    select * 
-    from {{ ref('stg_dashboard_pii__course_offerings_pd_workshops') }}
-),
+-- course_offerings_pd_workshops as ( 
+--     select * 
+--     from {{ ref('stg_dashboard_pii__course_offerings_pd_workshops') }}
+-- ),
 
-course_structure as (
-    select *
-        , replace(replace(replace(content_area, 'curriculum_', ''), '_self_paced_pl', ''), 'self_paced_pl_', '') as grade_band
-    from {{ ref('dim_course_structure') }}
-    where content_area != 'other'
-),
+-- course_structure as (
+--     select *
+--         , replace(replace(replace(content_area, 'curriculum_', ''), '_self_paced_pl', ''), 'self_paced_pl_', '') as grade_band
+--     from {{ ref('dim_course_structure') }}
+--     where content_area != 'other'
+-- ),
 
-course_grade_band as (
-    select distinct
-        course_name,
-        grade_band
-    from course_structure
-),
+-- course_grade_band as (
+--     select distinct
+--         course_name,
+--         grade_band
+--     from course_structure
+-- ),
 
-regional_partners as (
-    select * 
-    from {{ ref('dim_regional_partners') }}
-),
+-- regional_partners as (
+--     select * 
+--     from {{ ref('dim_regional_partners') }}
+-- ),
 
-course_scripts as (
-    select * 
-    from {{ ref('stg_dashboard__course_scripts') }}
-),
+-- course_scripts as (
+--     select * 
+--     from {{ ref('stg_dashboard__course_scripts') }}
+-- ),
 
-content_area_mapping as (
-    select distinct 
-        wco.course_offering_id,
-        cs.grade_band
-    from course_offerings_pd_workshops wco 
-    join course_offerings co 
-        on wco.course_offering_id = co.course_offering_id 
-    left join course_structure cs on co.key = cs.family_name
-),
+-- content_area_mapping as (
+--     select distinct 
+--         wco.course_offering_id,
+--         cs.grade_band
+--     from course_offerings_pd_workshops wco 
+--     join course_offerings co 
+--         on wco.course_offering_id = co.course_offering_id 
+--     left join course_structure cs on co.key = cs.family_name
+-- ),
 
 facilitated_pd as (
     select distinct 
@@ -121,11 +113,8 @@ facilitated_pd as (
         pdw.workshop_subject,
         pdw.workshop_started_at,
         pdw.is_byow,
-        case 
-            when pdw.course_name = 'build your own workshop' then co.display_name
-            else pdw.course_name
-        end                                             as topic,
-        coalesce(cam.grade_band, cg.grade_band)         as grade_band,
+        pdw.topic,
+        pdw.grade_band,
         tsh.school_id,
         schools.school_district_id,
         cast(null as bigint)                            as num_levels,
@@ -136,14 +125,14 @@ join pd_sessions pds
     on pda.pd_session_id = pds.pd_session_id
 join pd_workshops pdw
     on pds.pd_workshop_id = pdw.pd_workshop_id
-left join course_grade_band cg 
-    on pdw.course_name = cg.course_name
-left join course_offerings_pd_workshops copw 
-    on pdw.pd_workshop_id = copw.pd_workshop_id
-left join content_area_mapping cam 
-    on copw.course_offering_id = cam.course_offering_id
-left join course_offerings co 
-    on copw.course_offering_id = co.course_offering_id
+-- left join course_grade_band cg 
+--     on pdw.course_name = cg.course_name
+-- left join course_offerings_pd_workshops copw 
+--     on pdw.pd_workshop_id = copw.pd_workshop_id
+-- left join content_area_mapping cam 
+--     on copw.course_offering_id = cam.course_offering_id
+-- left join course_offerings co 
+--     on copw.course_offering_id = co.course_offering_id
 left join teacher_schools_historical tsh
     on pda.teacher_id = tsh.teacher_id
     and pda.school_year = tsh.started_at_sy

--- a/dbt/models/marts/professional_development/dim_pl_engagement.sql
+++ b/dbt/models/marts/professional_development/dim_pl_engagement.sql
@@ -24,6 +24,18 @@ active_teachers_sy_int as (
     join school_years 
         on active_teachers.school_year = school_years.school_year 
 ),
+    
+active_students_by_teacher as ( 
+    select 
+        active_students.teacher_id,
+        active_students.school_year,
+        school_years.school_year_int,
+        count(distinct active_students.student_id):: float as num_active_students
+    from {{ ref('dim_active_students') }} active_students
+    join school_years 
+        on active_students.school_year = school_years.school_year
+    group by 1,2,3
+),
 
 pl_with_engagement as (
     select 
@@ -76,7 +88,12 @@ select
         when act_1.teacher_id is not null and act_2.teacher_id is not null then 1.00 
         when act_2.teacher_id is not null and act_3.teacher_id is not null then 1.00
         else 0.00
-    end as sustained
+    end as sustained,
+    case 
+        when act_1.teacher_id is not null then act_stu_1.num_active_students 
+        when act_2.teacher_id is not null then act_stu_2.num_active_students 
+        else 0.00
+    end as num_active_students
 from pl_with_engagement pl
 left join active_teachers_sy_int act_1
     on pl.teacher_id = act_1.teacher_id 
@@ -87,6 +104,12 @@ left join active_teachers_sy_int act_2
 left join active_teachers_sy_int act_3
     on pl.teacher_id = act_3.teacher_id 
     and pl.school_year_int + 2 = act_3.school_year_int
+left join active_students_by_teacher act_stu_1
+    on pl.teacher_id = act_stu_1.teacher_id
+    and pl.school_year_int = act_stu_1.school_year_int
+left join active_students_by_teacher act_stu_2
+    on pl.teacher_id = act_stu_2.teacher_id 
+    and pl.school_year_int + 1 = act_stu_2.school_year_int
 
 
 

--- a/dbt/models/marts/professional_development/dim_pl_engagement.sql
+++ b/dbt/models/marts/professional_development/dim_pl_engagement.sql
@@ -25,17 +25,17 @@ active_teachers_sy_int as (
         on active_teachers.school_year = school_years.school_year 
 ),
     
-active_students_by_teacher as ( 
-    select 
-        active_students.teacher_id,
-        active_students.school_year,
-        school_years.school_year_int,
-        count(distinct active_students.student_id):: float as num_active_students
-    from {{ ref('dim_active_students') }} active_students
-    join school_years 
-        on active_students.school_year = school_years.school_year
-    group by 1,2,3
-),
+-- active_students_by_teacher as ( 
+--     select 
+--         active_students.teacher_id,
+--         active_students.school_year,
+--         school_years.school_year_int,
+--         count(distinct active_students.student_id):: float as num_active_students
+--     from {{ ref('dim_active_students') }} active_students
+--     join school_years 
+--         on active_students.school_year = school_years.school_year
+--     group by 1,2,3
+-- ),
 
 pl_with_engagement as (
     select 
@@ -90,10 +90,15 @@ select
         else 0.00
     end as sustained,
     case 
-        when act_1.teacher_id is not null then act_stu_1.num_active_students 
-        when act_2.teacher_id is not null then act_stu_2.num_active_students 
-        else 0.00
-    end as num_active_students
+        when act_1.teacher_id is not null then act_1.school_year
+        when act_2.teacher_id is not null then act_2.school_year 
+        else null
+    end as first_year_implemented
+    -- case 
+    --     when act_1.teacher_id is not null then act_stu_1.num_active_students 
+    --     when act_2.teacher_id is not null then act_stu_2.num_active_students 
+    --     else 0.00
+    -- end as num_active_students
 from pl_with_engagement pl
 left join active_teachers_sy_int act_1
     on pl.teacher_id = act_1.teacher_id 
@@ -104,12 +109,12 @@ left join active_teachers_sy_int act_2
 left join active_teachers_sy_int act_3
     on pl.teacher_id = act_3.teacher_id 
     and pl.school_year_int + 2 = act_3.school_year_int
-left join active_students_by_teacher act_stu_1
-    on pl.teacher_id = act_stu_1.teacher_id
-    and pl.school_year_int = act_stu_1.school_year_int
-left join active_students_by_teacher act_stu_2
-    on pl.teacher_id = act_stu_2.teacher_id 
-    and pl.school_year_int + 1 = act_stu_2.school_year_int
+-- left join active_students_by_teacher act_stu_1
+--     on pl.teacher_id = act_stu_1.teacher_id
+--     and pl.school_year_int = act_stu_1.school_year_int
+-- left join active_students_by_teacher act_stu_2
+--     on pl.teacher_id = act_stu_2.teacher_id 
+--     and pl.school_year_int + 1 = act_stu_2.school_year_int
 
 
 

--- a/dbt/models/marts/professional_development/dim_pl_workshops.sql
+++ b/dbt/models/marts/professional_development/dim_pl_workshops.sql
@@ -9,9 +9,13 @@ int_pl_workshops as (
         school_year,
         workshop_subject,
         workshop_started_at,
+        workshop_ended_at,
+        participant_group_type,
+        is_virtual,
         is_byow,
         num_teachers_enrolled,
         num_teachers_attended,
+        pct_teachers_attended,
         num_sessions,
         avg_sessions_attended,
         pct_sessions_attended,
@@ -19,7 +23,7 @@ int_pl_workshops as (
         listagg(distinct grade_band, ', ') within group (order by pl_workshop_id) as grade_bands
 
     from {{ ref('int_pl_workshops') }}
-    {{ dbt_utils.group_by(12) }}
+    {{ dbt_utils.group_by(16) }}
 ) 
 
 select * 

--- a/dbt/models/marts/professional_development/dim_pl_workshops.sql
+++ b/dbt/models/marts/professional_development/dim_pl_workshops.sql
@@ -1,147 +1,27 @@
 with 
 
-pd_enrollments as (
-    select * 
-    from {{ ref('stg_dashboard_pii__pd_enrollments') }}
-),
+int_pl_workshops as (
 
-pd_attendances as (
-    select * 
-    from {{ ref('stg_dashboard_pii__pd_attendances') }}
-),
-
-pd_sessions as (
-    select * 
-    from {{ ref('stg_dashboard_pii__pd_sessions') }}
-),
-
-course_offerings as ( 
-    select * 
-    from {{ ref('stg_dashboard__course_offerings') }}
-),
-
-course_offerings_pd_workshops as ( 
-    select * 
-    from {{ ref('stg_dashboard_pii__course_offerings_pd_workshops') }}
-),
-
-course_structure as (
-    select *
-        , replace(content_area, 'curriculum_', '') as grade_band
-    from {{ ref('dim_course_structure') }}
-    where content_area != 'other'
-),
-
-course_grade_band as (
-    select distinct
-        course_name,
-        grade_band
-    from course_structure
-),
-
-regional_partners as (
-    select * 
-    from {{ ref('dim_regional_partners') }}
-),
-
-content_area_mapping as (
-    select distinct 
-        wco.course_offering_id,
-        cs.grade_band
-    from course_offerings_pd_workshops wco 
-    join course_offerings co 
-        on wco.course_offering_id = co.course_offering_id 
-    left join course_structure cs on co.key = cs.family_name
-),
-
-enrollments_by_workshop as ( 
     select 
-        pd_workshop_id,
-        count(distinct teacher_id) as num_teachers_enrolled 
-    from pd_enrollments
-    group by 1
-),
+        pl_workshop_id,
+        pl_organizer_id,
+        pl_regional_partner_id,
+        school_year,
+        workshop_subject,
+        workshop_started_at,
+        is_byow,
+        num_teachers_enrolled,
+        num_teachers_attended,
+        num_sessions,
+        avg_sessions_attended,
+        pct_sessions_attended,
+        listagg(distinct topic, ', ') within group (order by pl_workshop_id) as topics,
+        listagg(distinct grade_band, ', ') within group (order by pl_workshop_id) as grade_bands
 
-sessions_by_workshop as (
-    select 
-        pd_workshop_id,
-        count(distinct pd_session_id) as num_sessions
-    from pd_sessions
-    group by 1
-),
+    from {{ ref('int_pl_workshops') }}
+    {{ dbt_utils.group_by(12) }}
+) 
 
-pd_workshops as (
-    select 
-        pd_workshop_id
-        , organizer_id
-        , school_year
-        , course_name
-        , subject as workshop_subject
-        , started_at as workshop_started_at
-        , regional_partner_id 
-        , is_byow
-    from {{ ref('stg_dashboard_pii__pd_workshops') }}
-),
+select * 
+from int_pl_workshops
 
-session_teacher_attendance as (
-    select 
-        pda.teacher_id,
-        pds.pd_workshop_id,
-        count(distinct pda.pd_session_id) as num_sessions_attended
-    from pd_attendances pda 
-    left join pd_sessions pds 
-        on pda.pd_session_id = pds.pd_session_id
-    group by 1,2
-),
-
-attendances_by_workshop as ( 
-    select 
-        pd_workshop_id,
-        count(distinct teacher_id) as num_teachers_attended 
-    from session_teacher_attendance
-    group by 1
-),
-
-avg_sessions_attended as (
-    select 
-        pd_workshop_id,
-        avg(cast(num_sessions_attended as float)) as avg_sessions_attended
-    from session_teacher_attendance
-    group by 1
-)
-
-select 
-    pd_workshops.pd_workshop_id as pl_workshop_id,
-    pd_workshops.organizer_id as pl_organizer_id,
-    pd_workshops.regional_partner_id as pl_regional_partner_id,
-    pd_workshops.school_year,
-    pd_workshops.workshop_subject,
-    pd_workshops.workshop_started_at,
-    is_byow,
-    case 
-        when pd_workshops.course_name = 'build your own workshop' then co.display_name
-        else pd_workshops.course_name
-    end                                             as topic,
-    coalesce(cam.grade_band, cg.grade_band)         as grade_band,
-    cast(e.num_teachers_enrolled as float),
-    cast(a.num_teachers_attended as float),
-    cast(s.num_sessions as float),
-    round(asa.avg_sessions_attended, 3) :: decimal(10,4) as avg_sessions_attended,
-    round(asa.avg_sessions_attended / s.num_sessions, 3) :: decimal(10,4) as pct_sessions_attended
-from pd_workshops
-left join enrollments_by_workshop e 
-    on pd_workshops.pd_workshop_id = e.pd_workshop_id
-left join attendances_by_workshop a 
-    on pd_workshops.pd_workshop_id = a.pd_workshop_id
-left join sessions_by_workshop s 
-    on pd_workshops.pd_workshop_id = s.pd_workshop_id
-left join avg_sessions_attended asa 
-    on pd_workshops.pd_workshop_id = asa.pd_workshop_id
-left join course_grade_band cg 
-    on pd_workshops.course_name = cg.course_name
-left join course_offerings_pd_workshops copw 
-    on pd_workshops.pd_workshop_id = copw.pd_workshop_id
-left join content_area_mapping cam 
-    on copw.course_offering_id = cam.course_offering_id
-left join course_offerings co 
-    on copw.course_offering_id = co.course_offering_id

--- a/dbt/models/marts/professional_development/dim_pl_workshops.sql
+++ b/dbt/models/marts/professional_development/dim_pl_workshops.sql
@@ -12,6 +12,7 @@ int_pl_workshops as (
         workshop_ended_at,
         participant_group_type,
         is_virtual,
+        is_upcoming,
         is_byow,
         num_teachers_enrolled,
         num_teachers_attended,
@@ -23,7 +24,7 @@ int_pl_workshops as (
         listagg(distinct grade_band, ', ') within group (order by pl_workshop_id) as grade_bands
 
     from {{ ref('int_pl_workshops') }}
-    {{ dbt_utils.group_by(16) }}
+    {{ dbt_utils.group_by(17) }}
 ) 
 
 select * 

--- a/dbt/models/marts/professional_development/dim_pl_workshops.sql
+++ b/dbt/models/marts/professional_development/dim_pl_workshops.sql
@@ -1,0 +1,147 @@
+with 
+
+pd_enrollments as (
+    select * 
+    from {{ ref('stg_dashboard_pii__pd_enrollments') }}
+),
+
+pd_attendances as (
+    select * 
+    from {{ ref('stg_dashboard_pii__pd_attendances') }}
+),
+
+pd_sessions as (
+    select * 
+    from {{ ref('stg_dashboard_pii__pd_sessions') }}
+),
+
+course_offerings as ( 
+    select * 
+    from {{ ref('stg_dashboard__course_offerings') }}
+),
+
+course_offerings_pd_workshops as ( 
+    select * 
+    from {{ ref('stg_dashboard_pii__course_offerings_pd_workshops') }}
+),
+
+course_structure as (
+    select *
+        , replace(content_area, 'curriculum_', '') as grade_band
+    from {{ ref('dim_course_structure') }}
+    where content_area != 'other'
+),
+
+course_grade_band as (
+    select distinct
+        course_name,
+        grade_band
+    from course_structure
+),
+
+regional_partners as (
+    select * 
+    from {{ ref('dim_regional_partners') }}
+),
+
+content_area_mapping as (
+    select distinct 
+        wco.course_offering_id,
+        cs.grade_band
+    from course_offerings_pd_workshops wco 
+    join course_offerings co 
+        on wco.course_offering_id = co.course_offering_id 
+    left join course_structure cs on co.key = cs.family_name
+),
+
+enrollments_by_workshop as ( 
+    select 
+        pd_workshop_id,
+        count(distinct teacher_id) as num_teachers_enrolled 
+    from pd_enrollments
+    group by 1
+),
+
+sessions_by_workshop as (
+    select 
+        pd_workshop_id,
+        count(distinct pd_session_id) as num_sessions
+    from pd_sessions
+    group by 1
+),
+
+pd_workshops as (
+    select 
+        pd_workshop_id
+        , organizer_id
+        , school_year
+        , course_name
+        , subject as workshop_subject
+        , started_at as workshop_started_at
+        , regional_partner_id 
+        , is_byow
+    from {{ ref('stg_dashboard_pii__pd_workshops') }}
+),
+
+session_teacher_attendance as (
+    select 
+        pda.teacher_id,
+        pds.pd_workshop_id,
+        count(distinct pda.pd_session_id) as num_sessions_attended
+    from pd_attendances pda 
+    left join pd_sessions pds 
+        on pda.pd_session_id = pds.pd_session_id
+    group by 1,2
+),
+
+attendances_by_workshop as ( 
+    select 
+        pd_workshop_id,
+        count(distinct teacher_id) as num_teachers_attended 
+    from session_teacher_attendance
+    group by 1
+),
+
+avg_sessions_attended as (
+    select 
+        pd_workshop_id,
+        avg(cast(num_sessions_attended as float)) as avg_sessions_attended
+    from session_teacher_attendance
+    group by 1
+)
+
+select 
+    pd_workshops.pd_workshop_id as pl_workshop_id,
+    pd_workshops.organizer_id as pl_organizer_id,
+    pd_workshops.regional_partner_id as pl_regional_partner_id,
+    pd_workshops.school_year,
+    pd_workshops.workshop_subject,
+    pd_workshops.workshop_started_at,
+    is_byow,
+    case 
+        when pd_workshops.course_name = 'build your own workshop' then co.display_name
+        else pd_workshops.course_name
+    end                                             as topic,
+    coalesce(cam.grade_band, cg.grade_band)         as grade_band,
+    cast(e.num_teachers_enrolled as float),
+    cast(a.num_teachers_attended as float),
+    cast(s.num_sessions as float),
+    round(asa.avg_sessions_attended, 3) :: decimal(10,4) as avg_sessions_attended,
+    round(asa.avg_sessions_attended / s.num_sessions, 3) :: decimal(10,4) as pct_sessions_attended
+from pd_workshops
+left join enrollments_by_workshop e 
+    on pd_workshops.pd_workshop_id = e.pd_workshop_id
+left join attendances_by_workshop a 
+    on pd_workshops.pd_workshop_id = a.pd_workshop_id
+left join sessions_by_workshop s 
+    on pd_workshops.pd_workshop_id = s.pd_workshop_id
+left join avg_sessions_attended asa 
+    on pd_workshops.pd_workshop_id = asa.pd_workshop_id
+left join course_grade_band cg 
+    on pd_workshops.course_name = cg.course_name
+left join course_offerings_pd_workshops copw 
+    on pd_workshops.pd_workshop_id = copw.pd_workshop_id
+left join content_area_mapping cam 
+    on copw.course_offering_id = cam.course_offering_id
+left join course_offerings co 
+    on copw.course_offering_id = co.course_offering_id

--- a/dbt/models/marts/professional_development/dim_self_paced_pd_activity.sql
+++ b/dbt/models/marts/professional_development/dim_self_paced_pd_activity.sql
@@ -16,6 +16,7 @@ course_structure as (
 user_levels as (
     select *
     from {{ ref('dim_user_levels') }}
+    where created_date > {{ get_cutoff_date() }} 
 ),
 
 teachers as (

--- a/dbt/models/marts/students/dim_active_students.sql
+++ b/dbt/models/marts/students/dim_active_students.sql
@@ -32,8 +32,8 @@ user_levels as (
         
     from {{ ref('dim_user_levels') }}
     where 
-        total_attempts > 0 
-        and created_date > {{ get_cutoff_date() }} 
+        -- total_attempts > 0 
+        created_date > {{ get_cutoff_date() }} 
 ), 
 
 projects as (

--- a/dbt/models/marts/students/dim_active_students.sql
+++ b/dbt/models/marts/students/dim_active_students.sql
@@ -32,8 +32,8 @@ user_levels as (
         
     from {{ ref('dim_user_levels') }}
     where 
-        -- total_attempts > 0 
-        created_date > {{ get_cutoff_date() }} 
+        total_attempts > 0 
+        and created_date > {{ get_cutoff_date() }} 
 ), 
 
 projects as (

--- a/dbt/models/marts/teachers/_teachers__models.yml
+++ b/dbt/models/marts/teachers/_teachers__models.yml
@@ -177,6 +177,7 @@ models:
   - name: dim_teacher_activity_daily
     description: |
       One row per teacher / activity date for every date a teacher had activity, where "activity" is defined by the following events tracked in Statsig (and their activity type classifications): 
+        
         curriculum catalog visited (light)    
         level activity (light)     
         lesson overview page visited (moderate)   

--- a/dbt/models/marts/users/dim_user_course_activity.sql
+++ b/dbt/models/marts/users/dim_user_course_activity.sql
@@ -68,6 +68,7 @@ school_years as (
 users as (
     select *
     from {{ ref('dim_users') }}
+    where user_type = 'student'
 ),
 
 combined as (

--- a/dbt/models/staging/dashboard_pii/base/base_dashboard_pii__pd_workshops.sql
+++ b/dbt/models/staging/dashboard_pii/base/base_dashboard_pii__pd_workshops.sql
@@ -26,7 +26,8 @@ renamed as (
         on_map              as is_on_map,
         funded              as is_funded,
         funding_type,
-        -- properties,
+        participant_group_type,
+        properties,
         module -- (js) new col added (see: https://github.com/code-dot-org/code-dot-org/pull/53949/files)
     from source
 )

--- a/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_attendances.sql
+++ b/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_attendances.sql
@@ -14,3 +14,4 @@ select
     sy.school_year
 from pd_attendances pda
 join school_years sy on pda.created_at between sy.started_at and sy.ended_at
+where pda.created_at > {{ get_cutoff_date() }} 

--- a/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_enrollments.sql
+++ b/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_enrollments.sql
@@ -18,3 +18,4 @@ select
     , application_id 
 
 from pd_enrollments
+where enrolled_at > {{ get_cutoff_date() }} 

--- a/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_sessions.sql
+++ b/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_sessions.sql
@@ -22,3 +22,4 @@ select
 from pd_sessions                                                                                as pds
 join school_years                                                                               as sy
     on pds.started_at between sy.started_at and sy.ended_at
+where pds.started_at > {{ get_cutoff_date() }} 

--- a/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_workshops.sql
+++ b/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_workshops.sql
@@ -56,6 +56,12 @@ select
     -- , is_funded
     -- , funding_type
     , module
+    , lower(participant_group_type) as participant_group_type
+    , case 
+        when json_extract_path_text(properties, 'virtual') = 'true' then 1 
+        when json_extract_path_text(properties, 'virtual') = 'false' then 0 
+        else null 
+    end as is_virtual
 from pd_workshops                                           as pdw
 join school_years                                           as sy
     on pdw.started_at between sy.started_at and sy.ended_at

--- a/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_workshops.sql
+++ b/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_workshops.sql
@@ -62,6 +62,12 @@ select
         when json_extract_path_text(properties, 'virtual') = 'false' then 0 
         else null 
     end as is_virtual
+    -- , case 
+    --     when pdw.started_at is null 
+    --         or pdw.started_at > current_date() 
+    --     then 1
+    --     else 0                 
+    -- end as is_upcoming
 from pd_workshops                                           as pdw
 join school_years                                           as sy
-    on pdw.started_at between sy.started_at and sy.ended_at
+    on coalesce(pdw.started_at, pdw.created_at) between sy.started_at and sy.ended_at

--- a/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_workshops.sql
+++ b/dbt/models/staging/dashboard_pii/stg_dashboard_pii__pd_workshops.sql
@@ -71,3 +71,4 @@ select
 from pd_workshops                                           as pdw
 join school_years                                           as sy
     on coalesce(pdw.started_at, pdw.created_at) between sy.started_at and sy.ended_at
+where coalesce(pdw.started_at, pdw.created_at) > {{ get_cutoff_date() }} 


### PR DESCRIPTION
This PR: 
- creates int_pl_workshops, used as an intermediate model to dim_pl_activity - on the grain of workshop id / topic
- creates dim_pl_workshops that is meant to be user facing and is on the grain of workshop id, aggregating the topics and grade bands covered. 
- adds documentation for dim_pl_workshops 
- fixes the use of "int_teacher_schools_historical"