### PR TITLE
Adhoc/add section info

### DIFF
--- a/dbt/models/intermediate/int_section_mapping.sql
+++ b/dbt/models/intermediate/int_section_mapping.sql
@@ -39,6 +39,11 @@ sections as (
     from {{ ref('stg_dashboard__sections') }}
 ),
 
+schools as (
+    select * 
+    from {{ ref('dim_schools') }}
+),
+
 combined as (
     select 
         sy.school_year, 
@@ -47,6 +52,7 @@ combined as (
         sections.section_id                                                 as section_id,
         tsc.school_id,
         tsc.school_info_id,
+        schools.school_district_id,
         student_added_at,
         case 
             when 
@@ -73,6 +79,8 @@ combined as (
     left join teacher_school_changes tsc 
         on sections.teacher_id = tsc.teacher_id 
         and sy.ended_at between tsc.started_at and tsc.ended_at 
+    left join schools 
+        on tsc.school_id = schools.school_id 
 ),
 
 final as (
@@ -83,6 +91,7 @@ final as (
         teacher_id,
         school_id,
         school_info_id,
+        school_district_id,
         student_added_at,
         student_removed_at
     from combined

--- a/dbt/models/marts/students/_students__models.yml
+++ b/dbt/models/marts/students/_students__models.yml
@@ -77,6 +77,7 @@ models:
         - `sign-ins` 
         - `projects`  
 
+      There is a row for every date a given student is active, and for every section they are in in that school year. So, if a student is in multiple sections in a given school year, every row for that student will be duplicated for each section ID. Always count distinct! 
     columns:
       - name: activity_date
         description: "The date on which activity was recorded for the user, merged across all aggregated activity types."
@@ -101,6 +102,18 @@ models:
       - name: school_year
         description: "The school year during which the activity occurred, determined by matching the activity date with school year ranges. A school year is defined as the 365 days between July 1 in year 1, and June 30 in year 2."
         data_type: "varchar"
+      
+      - name: section_id
+        description: The section ID associated with the student in the school year of the activity date. If the student is associated with multiple sections that school year, there will be a row for every section they are in for every date they have activity.
+      
+      - name: teacher_id
+        description: the teacher ID associated with the section the student is in in that school year. 
+      
+      - name: school_id
+        description: the NCES school ID associated with the teacher of the section the student is in in that school year. Null if not in a section or teacher has not chosen school. 
+
+      - name: school_district_id
+        description: the NCES school district ID associated with their section's teacher, null if the teacher did not choose a school. 
 
       - name: has_sign_in_activity
         description: "`0|1` flag indicating whether there was any sign-in activity for the user on the given day (1 for yes, 0 for no)."
@@ -121,6 +134,7 @@ models:
           combination_of_columns:
             - student_id
             - activity_date
+            - section_id
 
   - name: dim_students
     description: |

--- a/dbt/models/marts/students/dim_active_students.sql
+++ b/dbt/models/marts/students/dim_active_students.sql
@@ -75,6 +75,11 @@ combined as (
         extract(year from uni.activity_date)   as cal_year,
         sy.school_year,
 
+        sm.section_id,
+        sm.teacher_id,
+        sm.school_id,
+        sm.school_district_id,
+
         max(uni.has_user_level_activity)       as has_user_level_activity,
         max(uni.has_project_activity)          as has_project_activity
 
@@ -87,12 +92,11 @@ combined as (
             between sy.started_at
                 and sy.ended_at 
     
-    -- left join section_mapping sm 
-    --     on uni.user_id = section_mapping.student_id
-    --         and sy.school_year = section_mapping.school_year
+    left join section_mapping sm 
+        on uni.user_id = section_mapping.student_id
+            and sy.school_year = section_mapping.school_year
 
-
-    {{ dbt_utils.group_by(8) }} 
+    {{ dbt_utils.group_by(12) }} 
 ),
 
 final as (

--- a/dbt/models/marts/students/dim_active_students.sql
+++ b/dbt/models/marts/students/dim_active_students.sql
@@ -17,6 +17,11 @@ users as (
     where user_type = 'student'
 ),
 
+section_mapping as (
+    select * 
+    from {{ ref('int_section_mapping') }}
+),
+
 user_levels as (
     select  
 
@@ -81,6 +86,11 @@ combined as (
         on uni.activity_date 
             between sy.started_at
                 and sy.ended_at 
+    
+    -- left join section_mapping sm 
+    --     on uni.user_id = section_mapping.student_id
+    --         and sy.school_year = section_mapping.school_year
+
 
     {{ dbt_utils.group_by(8) }} 
 ),

--- a/dbt/models/marts/students/dim_active_students.sql
+++ b/dbt/models/marts/students/dim_active_students.sql
@@ -93,8 +93,8 @@ combined as (
                 and sy.ended_at 
     
     left join section_mapping sm 
-        on uni.user_id = section_mapping.student_id
-            and sy.school_year = section_mapping.school_year
+        on uni.user_id = sm.student_id
+            and sy.school_year = sm.school_year
 
     {{ dbt_utils.group_by(12) }} 
 ),


### PR DESCRIPTION
this PR adds the section/teacher/school/district associated with the student in the school year of their activity. This will duplicate records for every section the student is in in a given school year for every day of activity. Since the model already requires a count distinct on almost every aggregation one would make, we anticipate the risk of overcounting to be low, and a risk we think is worth the associated simplicity of adding the ids to a single model. 

Another risk to consider is the number of rows this addition would be adding to dim_active_students. Before the addition, here are the row counts by school year: 

2019-20 | 63707364
2020-21 | 72704669
2021-22 | 78850475
2022-23 | 77495252
2023-24 | 77697216
2024-25 | 31403006

After the addition of section_id: 

2019-20 | 69489948 (9% increase)
2020-21 | 79677993 (9.5% increase)
2021-22 | 86568860 (9.8% increase)
2022-23 | 85426341 (10.2% increase)
2023-24 | 85116388 (9.5% increase)
2024-25 | 33936091 (8% increase)

The other solution proposed was a separate model on the school_year/student_id/ section_id grain, which would not have the daily duplication that this solution would have. However, many use cases for counting up active students (e.g. district team wanting to count active students by month among enrolled districts) would not be able to be served by this solution. 