### PR TITLE
Feature/student course enrollment

### DIFF
--- a/dbt/models/reporting_views/Tableau_Dashboards/view_student_course_participation.sql
+++ b/dbt/models/reporting_views/Tableau_Dashboards/view_student_course_participation.sql
@@ -1,0 +1,122 @@
+/* Created 01/01/28: View for students starting a course for Course Participation dashboard in Tableau  
+This view has a record for every student/course/school year for student-facing curriculum, along with demographics and school characteristics 
+*/
+
+with
+
+school_years as (
+    select * 
+    from {{ref('int_school_years')}} 
+    where sysdate-(365*3) < ended_at and sysdate > started_at -- four most recent school years (current and prior 3), to change the number of years, change the multiplier
+)
+
+
+, student_activity as (
+    select sa.*
+    , sy.started_at as sy_start_at
+    from {{ ref('dim_user_course_activity') }} sa
+    join school_years sy on sa.school_year = sy.school_year -- limit to selected school years
+    where 
+    user_type = 'student'
+    and content_area not in ('other')
+)
+
+, schools as 
+(
+    select 
+        school_id
+        , school_name
+        , school_type
+        , school_district_id
+        , school_district_name
+        , state                                         as school_state
+        , coalesce(dss.is_title_i,0)                    as is_title_i 
+		, coalesce(dss.frl_eligible_percent,0)          as frl_eligible_percent 
+		, coalesce(dss.urg_no_tr_numerator_percent,0)   as urg_percent 
+		, coalesce(dss.is_rural,0)                      as is_rural
+        ,  case	
+            when 	coalesce(dss.is_title_i,0) = 1 
+		        or	coalesce(dss.frl_eligible_percent,0) > 0.4 
+		        or	coalesce(dss.urg_no_tr_numerator_percent,0) > 0.3 
+		        or	coalesce(dss.is_rural,0) = 1
+            then 1 else 0 
+            end school_is_uu
+    from {{ref('dim_schools')}} dss
+)
+
+, section_mapping as (
+    select *
+    from {{ ref('int_section_mapping') }}
+    
+    where student_id in (
+        select user_id 
+        from student_activity )
+                -- Restrict to students with relevant activity
+
+)
+
+, section_size as (
+    select 
+        section_id
+        , count(distinct student_id) as section_size 
+    from section_mapping
+    {{ dbt_utils.group_by(1) }}
+)
+
+, student_section as (
+    select 
+        scm.*     
+        , scz.section_size
+    
+    from section_mapping    as scm 
+    join section_size       as scz 
+        on scm.section_id   = scz.section_id
+)
+
+, final as (
+select 
+  sa.user_id as student_id
+, sa.school_year 
+, sa.content_area
+, sa.course_name
+, sa.topic_tags
+, sa.us_intl
+, sa.country
+, sa.num_unique_days
+, sa.num_levels
+, sa.num_levels_course_progress
+, sec.school_id
+, ss.school_name
+, ss.school_type
+, ss.is_title_i 
+, ss.frl_eligible_percent 
+, ss.urg_percent 
+, ss.is_rural
+, ss.school_is_uu
+, ss.school_district_id
+, ss.school_district_name
+, ss.school_state
+
+from student_activity   as  sa
+left join student_section      as  sec
+    on  sa.user_id      =   sec.student_id
+    and sa.school_year  =   sec.school_year
+    and sa.first_activity_at    <=  sec.student_removed_at
+    and sa.last_activity_at     >=  sec.student_added_at
+left join schools       as ss
+        on sec.school_id    = ss.school_id 
+
+{{ dbt_utils.group_by(21) }} -- grouping instead of select distinct to deduplicate records with better performance
+)
+
+select
+school_year
+, course_name
+, count (distinct student_id) n_students
+from final
+where 
+us_intl = 'us'
+-- and course_name = 'csf'
+and num_unique_days >= 5
+{{ dbt_utils.group_by(2) }}
+order by 1,2

--- a/dbt/models/reporting_views/Tableau_Dashboards/view_student_course_participation.sql
+++ b/dbt/models/reporting_views/Tableau_Dashboards/view_student_course_participation.sql
@@ -73,7 +73,6 @@ school_years as (
         on scm.section_id   = scz.section_id
 )
 
-, final as (
 select 
   sa.user_id as student_id
 , sa.school_year 
@@ -96,6 +95,7 @@ select
 , ss.school_district_id
 , ss.school_district_name
 , ss.school_state
+, sec.section_size
 
 from student_activity   as  sa
 left join student_section      as  sec
@@ -106,17 +106,4 @@ left join student_section      as  sec
 left join schools       as ss
         on sec.school_id    = ss.school_id 
 
-{{ dbt_utils.group_by(21) }} -- grouping instead of select distinct to deduplicate records with better performance
-)
-
-select
-school_year
-, course_name
-, count (distinct student_id) n_students
-from final
-where 
-us_intl = 'us'
--- and course_name = 'csf'
-and num_unique_days >= 5
-{{ dbt_utils.group_by(2) }}
-order by 1,2
+{{ dbt_utils.group_by(22) }} -- grouping instead of select distinct to deduplicate records with better performance

--- a/dbt/models/reporting_views/_reporting_views.yml
+++ b/dbt/models/reporting_views/_reporting_views.yml
@@ -27,6 +27,15 @@ models:
     config:
       tags: ['reporting', 'tableau']
 
+
+  - name: view_student_course_participation
+    description: |
+      Students starting a course in a school year for Course Participation dashboard in Tableau. Includes student-facing curriculum, along with sdtuent demographics and school characteristics.
+   
+    config:
+      tags: ['reporting', 'tableau']
+
+
 ## Daily participating students
   - name: daily_participating_students
     description: |


### PR DESCRIPTION
This PR creates a view to gather the necessary data to replicate the[ Student Enrollment dashboard](https://us-east-1.online.tableau.com/t/codeorg/views/EnrollmentDemographics/EnrollmentDemographics) in Tableau. 

There is a difference worth noting to the current enrollment dashboard: the new view doesn't include HOC activity because 1) it is pulling from `dim_user_course_activity` as this is a dashboard aggregating by course and school year. 2) I think it is good not to include HOC because we only have HOC activity for signed-in users so it can be confusing/misleading to display it.

<!--
changelog:
auth.      descr.      date
natalia        init        02-07-2025 
-->