### PR TITLE
limit user type to students in active sections

### DIFF
--- a/dbt/models/intermediate/int_active_sections.sql
+++ b/dbt/models/intermediate/int_active_sections.sql
@@ -10,6 +10,7 @@ student_course_starts as (
     select *
     from {{ ref('dim_user_course_activity') }}
     where user_id in (select student_id from student_section)
+    and user_type = 'student'
 ),
 
 combined as (


### PR DESCRIPTION
This addition limits active sections to only count activity from _students_, as opposed to all users. 
