### PR TITLE
Removes  filter on scripts where instruction_type = 'self-paced'

### DIFF
--- a/dbt/models/marts/professional_development/dim_self_paced_pd_activity.sql
+++ b/dbt/models/marts/professional_development/dim_self_paced_pd_activity.sql
@@ -1,14 +1,11 @@
 with 
 course_structure as (
-    select *
+    select 
+    *
     from {{ ref('dim_course_structure') }}
     where 
         course_name != 'other'
-        and 
-        (
-        participant_audience = 'teacher'
-        and instruction_type = 'self_paced'
-        )
+        and participant_audience = 'teacher'
         and script_name not in ('alltheselfpacedplthings')
         and content_area like '%self_paced_pl%'
 ),


### PR DESCRIPTION
This fix removes the filter on scripts set to have instruction_type = 'self-paced' to reduce issues due to errors given that the content area is mostly sufficient to denote self-paced scripts. 

Test case: script _k5-onlinepd-2023_  is missing in `dim_self_paced_pd_activity` because it has instruction_type = 'teacher-led'. Given that it has been classified as self-paced pd in the `content_area` field,  it should now be included in the model.

Query for Testing:
```
with 
prod as 
(
select 
content_area
, course_name
, script_name
, 'prod' as source
, count (distinct sp.teacher_id) n_users
from analytics.dim_self_paced_pd_activity sp 
where 
sp.content_area like 'self_paced_pl_k_5'
and sp.level_created_school_year = '2024-25'
group by 1,2,3,4
)
, dev as 
(
select 
content_area
, course_name
, script_name
, 'dev' as source
, count (distinct sp.teacher_id) n_users
from dbt_natalia.dim_self_paced_pd_activity sp 
where 
sp.content_area like 'self_paced_pl_k_5'
and sp.level_created_school_year = '2024-25'
group by 1,2,3,4
)
--
select * 
from dev d
full outer join prod p 
on 		d.content_area = p.content_area 
	and d.script_name = p.script_name
where 
d.script_name is null 
or  p.script_name is null
order by 1,2
;
```


