### PR TITLE
testing change of attempts > 0 to compare before and after

### DIFF
--- a/dbt/models/marts/users/dim_user_levels.sql
+++ b/dbt/models/marts/users/dim_user_levels.sql
@@ -21,6 +21,7 @@ user_levels as (
         sum(attempts)           as total_attempts,
         max(best_result)        as best_result
     from {{ ref('stg_dashboard__user_levels') }}    
+    where attempts > 0
     {{ dbt_utils.group_by(8) }}
 ),
 


### PR DESCRIPTION


# Description

Currently, we have two different thresholds for whether levels with attempts = 0 'count' in  our data. They currently do not count for dim_user_course_activity and other sources, but they do count for active and participating students, which are based on dssla. This updates dim_user_levels and all later models to limit to usage where attempts>0.

This fixes this lack of alignment within the RED team metrics. 

See Natalia's recommendation on this change here: https://codedotorg.slack.com/archives/C071T8M847J/p1742246516575079


## Links

Jira ticket(s): [https://codedotorg.atlassian.net/browse/DATAOPS-1101](https://codedotorg.atlassian.net/browse/DATAOPS-1101)

## Testing story
Tested on 
- active students
- participating students

and found <.1% change to those metrics. 

## Privacy

- [ ] 1.	Does this change involve the collection, use, or sharing of new Personal Data?
- [ ] 2.    Do these data exist in the appropriate schema(s)? 
- [ ] 3.	Does this change involve a new or changed use or sharing of existing Personal Data?
- [ ] 4.    Consider: will this data be visible on Tableau? will this data be surfaced in a report exported from Trevor?
- [ ] 5.    If yes to any of the above, please list the models, columns, and justification below:
      i.
      ii.
      iii. 


## PR Checklist:
--> **Note: if these are not all checked, the PR will be sent back.**

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code adheres to [style guide](https://docs.getdbt.com/best-practices/how-we-style/0-how-we-style-our-dbt-projects)👀 and is **[DRY](https://docs.getdbt.com/terms/dry)**
- [ ] Code is well-commented (**please do not leave extraneous commentary in model code, if it is for the purpose of documentation, please relocate accordingly)
- [ ] Appropriate documentation has been provided (see `.yml.`, did `dbt docs generate` succeed?)
- [ ] New features are translatable or updates will not break up/downstream models
- [ ] Relevant documentation has been added or updated (i.e. `dbt docs` has been updated successfully on [Github Pages](code-dot-org.github.io/analytics/)
- [ ] Pull Request is labeled appropriately (eg. `chore/`, `feature/`, `fix/`)
- [ ] Follow-up work items (including potential tech debt) are tracked and linked (if applicable)



<!--
changelog:
auth.      descr.      date
js         init        2024-01-22              
js         v1.2        2024-02-06
-->