### PR TITLE
Fix/add school year week to curriculum students

### DIFF
--- a/dbt/models/marts/metrics/_metrics__models.yml
+++ b/dbt/models/marts/metrics/_metrics__models.yml
@@ -160,6 +160,8 @@ models:
           - not_null
       - name: week_number
         description: ISO week number
+      - name: school_year_week
+        description: week of the school year (starts July 1, ends June 30)
       - name: n_students
         description: number of unique students meeting at least 1+ day of curriculum (including HS). This is the number to use for reporting total curriculum students externally.
       - name: n_students_adj

--- a/dbt/models/marts/metrics/_metrics__models.yml
+++ b/dbt/models/marts/metrics/_metrics__models.yml
@@ -160,7 +160,7 @@ models:
           - not_null
       - name: week_number
         description: ISO week number
-      - name: school_year_week
+      - name: week_number_school_year
         description: week of the school year (starts July 1, ends June 30)
       - name: n_students
         description: number of unique students meeting at least 1+ day of curriculum (including HS). This is the number to use for reporting total curriculum students externally.

--- a/dbt/models/marts/metrics/_metrics__models.yml
+++ b/dbt/models/marts/metrics/_metrics__models.yml
@@ -182,6 +182,12 @@ models:
         description: school year to date counts for that school year for ES, adjusted to account for expected 40% anonymous. Code.org goals should use the adjusted number for ES. External reporting should not use this number. 
         data_tests:
           - not_null
+    data_tests:
+    - dbt_utils.unique_combination_of_columns:
+        combination_of_columns:
+          - country
+          - qualifying_date
+
     config:
       tags: ['released','reporting']
 

--- a/dbt/models/marts/metrics/fct_daily_curriculum_student_users.sql
+++ b/dbt/models/marts/metrics/fct_daily_curriculum_student_users.sql
@@ -7,6 +7,7 @@ This is a daily cut so that the stakeholders can see YOY changes below the schoo
 Edit log: 
 
 2025-03-17 CK - edited to make global + replaced dssla with duca as a source of all_students data (for speed)
+2025-04-17 CK - edited to add school year week
 
 */
 

--- a/dbt/models/marts/metrics/fct_daily_curriculum_student_users.sql
+++ b/dbt/models/marts/metrics/fct_daily_curriculum_student_users.sql
@@ -151,7 +151,7 @@ with curriculum_counts as (
         calculations.school_year
         , qualifying_date
         , date_part(week, qualifying_date)::int week_number
-        , sw.week_number_school_year
+        , sw.school_year_week as week_number_school_year
         , decode (date_part(dayofweek, qualifying_date),
                      0, 'sun',
                      1, 'mon',

--- a/dbt/models/marts/metrics/fct_daily_curriculum_student_users.sql
+++ b/dbt/models/marts/metrics/fct_daily_curriculum_student_users.sql
@@ -151,7 +151,7 @@ with curriculum_counts as (
         calculations.school_year
         , qualifying_date
         , date_part(week, qualifying_date)::int week_number
-        , sw.school_year_week
+        , sw.week_number_school_year
         , decode (date_part(dayofweek, qualifying_date),
                      0, 'sun',
                      1, 'mon',


### PR DESCRIPTION

# Description

Quick PR to add school year week to dim_curriculum_students to enable a Trevor dashboard Martina is trying to build. 

Docs updated to include the new field