### PR TITLE
Fix/dim sections

### DIFF
--- a/dbt/models/marts/sections/dim_sections.sql
+++ b/dbt/models/marts/sections/dim_sections.sql
@@ -101,7 +101,7 @@ teacher_school_changes as (
         -- section activity within a school/school year
         act.school_id,
         act.course_name,
-        coalesce(act.is_active,0) is_active
+        coalesce(act.is_active,0) is_active,
         act.num_students_active,
         act.section_started_at,     
         coalesce(act.school_year, nsps.school_year) school_year    -- coalesce first activity school_year with year of student activity

--- a/dbt/models/marts/sections/dim_sections.sql
+++ b/dbt/models/marts/sections/dim_sections.sql
@@ -96,7 +96,7 @@ teacher_school_changes as (
         -- section activity within a school/school year
         act.school_id,
         act.course_name,
-        act.is_active,
+        coalesce(act.is_active,0) is_active
         act.num_students_active,
         act.section_started_at,     
         coalesce(act.school_year, nsps.school_year) school_year    -- coalesce first activity school_year with year of student activity

--- a/dbt/models/marts/sections/dim_sections.sql
+++ b/dbt/models/marts/sections/dim_sections.sql
@@ -113,7 +113,7 @@ teacher_school_changes as (
             nsps.section_id = act.section_id
             and nsps.school_year = act.school_year
             and nsps.teacher_id = act.teacher_id
-            and nsps.school_id = act.school_id 
+            and coalesce(nsps.school_id,'0') = coalesce(act.school_id,'0') 
 )
 select *
 from final

--- a/dbt/models/marts/sections/dim_sections.sql
+++ b/dbt/models/marts/sections/dim_sections.sql
@@ -11,6 +11,11 @@ some of them for clarity -- noted in inline comments below.
 This model should have every distinct section_id that appears in stg__sections.  However, some sections 
 will show students added but no activity because the activity is excluded by int_active_sections.
 
+
+-- Updated by Natalia 04/22/25
+1. Changed join from sections to active courses to use a coalesce around school_id to bring in active sections not associated to an NCES school
+2. Added coalesce(is_active,0) to avoid nulls on this field
+
 #}
 
 with school_years as (


### PR DESCRIPTION
**Problem:**
`dim_sections` was counting a section as active only when it had an NCES-associated school. This was leaving out international sections and sections where a school was manually associated, even if they were active per the [definition](https://github.com/code-dot-org/analytics/blob/main/dbt/models/marts/sections/_sections.yml):
All sections ever created, with activity metrics for those that are "active" (5+ students starting 1+ levels of same course during a school year).

**Fixes:**

1. Changed join from sections to active courses to use a coalesce around `school_id` to bring in active sections not associated to an NCES school
2. Added `coalesce(is_active,0)` to avoid nulls on this field

**Tests:**

1.  The code below pulls a list of active sections
a. New 
```
select *
from dbt_natalia.dim_sections
where 
school_year = '2023-24'
and
num_students_active is not null
and school_id is null;
``` 
b. Old (empty list)
```
select *
from analytics.dim_sections
where 
school_year = '2023-24'
and
num_students_active is not null
and school_id is null;
``` 

2. The code below pulls a list of inactive sections
a. New
```
select *
from dbt_natalia.dim_sections
where 
is_active <> 1
limit 100
;
```  
b. Old: pulls an empty list
```
select *
from analytics.dim_sections
where 
is_active <> 1
limit 100;
```