### PR TITLE
Fix/dim curriculum survey responses

### DIFF
--- a/dbt/models/marts/students/_students__models.yml
+++ b/dbt/models/marts/students/_students__models.yml
@@ -422,11 +422,11 @@ models:
       - name: us_intl
         description: "" 
 
-      - name: gender
-        description: "" 
+      - name: gender_group
+        description: Recoded gender information 
 
-      - name: races
-        description: "" 
+      - name: race_group
+        description: Recoded race information 
 
       - name: is_urg 
         description: "" 
@@ -486,6 +486,18 @@ models:
 
       - name: answer_response
         description: "" 
+      
+      - name: num_response_options
+        description: number of options available to the survey question 
+      
+      - name: user_level_id
+        description: "" 
+      
+      - name: level_source_id
+        description: use this to join to the level_sources data if needed 
+      
+      - name: data
+        description: source data in level_sources, useful to verify
     
     config:
       tags: ['released']

--- a/dbt/models/marts/students/dim_curriculum_survey_responses.sql
+++ b/dbt/models/marts/students/dim_curriculum_survey_responses.sql
@@ -146,7 +146,3 @@ combined as (
 
 select * 
 from combined 
-    -- where survey_name = 'csp-post-survey-levelgroup_2024'
-	-- 	and (question_text like '%top two reasons%'
-	-- 	or question_text like '%family member%'
-	-- 	or question_text like '%encourage more of your friends%')

--- a/dbt/models/marts/students/dim_curriculum_survey_responses.sql
+++ b/dbt/models/marts/students/dim_curriculum_survey_responses.sql
@@ -36,21 +36,23 @@ level_sources as (
 ),
 
 level_sources_multi as (
-(select 
-*
-, regexp_substr(data,'[^,]*') answer_multi
-from level_sources
-where regexp_substr(data,'[^,]*') is not null
-) -- first response
+    (
+        select
+            *
+            , regexp_substr(data,'[^,]*') answer_multi
+        from level_sources
+        where regexp_substr(data,'[^,]*') is not null
+    ) -- first response
 union all 
-(select 
-*
-, regexp_substr(data,'[0-9]+$', 1, 1) answer_multi
-from level_sources
-where 
-    regexp_substr(data,'[0-9]+$', 1, 1) is not null     -- second answer is not null
-    and regexp_substr(data,'[^,]*') != data             -- first answer is not the only answer, in which case it will be the same as data
-) -- second response
+    (
+        select 
+            *
+            , regexp_substr(data,'[0-9]+$', 1, 1) answer_multi
+    from level_sources
+    where 
+        regexp_substr(data,'[0-9]+$', 1, 1) is not null     -- second answer is not null
+        and regexp_substr(data,'[^,]*') != data             -- first answer is not the only answer, in which case it will be the same as data
+    ) -- second response
 ),
 
 users as (
@@ -145,7 +147,7 @@ combined as (
             and sy.ended_at 
             
     {{ dbt_utils.group_by(30) }} -- To get unduplicated rows, better performing than select distinct
-    )
+)
 
 select * 
 from combined 

--- a/dbt/models/marts/students/dim_curriculum_survey_responses.sql
+++ b/dbt/models/marts/students/dim_curriculum_survey_responses.sql
@@ -40,13 +40,16 @@ level_sources_multi as (
 *
 , regexp_substr(data,'[^,]*') answer_multi
 from level_sources
+where regexp_substr(data,'[^,]*') is not null
 ) -- first response
 union all 
 (select 
 *
 , regexp_substr(data,'[0-9]+$', 1, 1) answer_multi
 from level_sources
-where regexp_substr(data,'[0-9]+$', 1, 1) is not null
+where 
+    regexp_substr(data,'[0-9]+$', 1, 1) is not null     -- second answer is not null
+    and regexp_substr(data,'[^,]*') != data             -- first answer is not the only answer, in which case it will be the same as data
 ) -- second response
 ),
 


### PR DESCRIPTION
### **This PR edits the `dim_curriculum_survey_responses` model to pull in answers to questions that have multiple choices selected.** 
In the curriculum these questions are of the type 'choose two'. By using regular expressions to decompose the two selected choices and then match them to their lookup value, this update now includes those values which appeared null before. 


**Test case:**
Values from the 'prod set' would have null values in the `answer_response` field
```
with 
prod as (
select
student_id
, script_id
, survey_level_id
, contained_level_id
, user_level_id
, level_source_id
, question_type
, question_text
, answer_response 
, answer_number
from 
dev.analytics.dim_curriculum_survey_responses
where school_year = '2023-24'
and course_name = 'csa'
)
, test as 
 (
select
student_id
, script_id
, survey_level_id
, contained_level_id
, user_level_id
, level_source_id
, question_type
, question_text
, answer_response 
, answer_number
from 
dev.dbt_natalia.dim_curriculum_survey_responses
where school_year = '2023-24'
and course_name = 'csa'
)
select t.*, p.*
from test t
left join prod p on
t.student_id = p.student_id
and t.script_id = p.script_id
and t.survey_level_id = p.survey_level_id
and t.contained_level_id = p.contained_level_id
and t.user_level_id = t.user_level_id
and t.level_source_id = p.level_source_id
where coalesce(t.answer_response,'') != coalesce(p.answer_response,'') -- responses that were not captured with previous code. If working as expected, prod records have null values in answer_response
limit 200
;

